### PR TITLE
ci: smoke-test strict wp-templates (do not merge)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,59 +1,33 @@
+---
 name: Lint
-permissions:
-  contents: read
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - '**/*.php'
       - 'composer.json'
       - 'composer.lock'
+      - 'phpcs.xml'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon'
+      - 'phpstan-bootstrap.php'
+      - 'languages/**'
   pull_request:
     paths:
       - '**/*.php'
       - 'composer.json'
       - 'composer.lock'
+      - 'phpcs.xml'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon'
+      - 'phpstan-bootstrap.php'
+      - 'languages/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   lint:
-    name: QA
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php: ["8.3", "8.4"]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: curl
-          coverage: none
-          tools: composer:v2, cs2pr
-
-      - name: Validate PHP syntax
-        run: find . -maxdepth 1 -name '*.php' -exec php --syntax-check {} +
-
-      - name: Validate composer.json
-        run: composer validate --no-check-publish
-
-      - run: composer install --no-progress --prefer-dist --optimize-autoloader --no-suggest
-
-      - run: vendor/bin/phpcs -q --report=checkstyle | cs2pr
-
-      - run: ./vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr
-
-      - name: Run wp-plugin-check
-        if: matrix.php == '8.4'
-        uses: wordpress/plugin-check-action@v1
-        with:
-          exclude-checks: |
-            late_escaping
-            plugin_review_phpcs
-            file_type
-            plugin_readme
-          exclude-files: phpstan-bootstrap.php
+    uses: oszuidwest/.github-templates/.github/workflows/wp-ci.yml@bd7984b073a684089c53524f7c5f52869d91fe0a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,133 +1,22 @@
-name: Publish Plugin Release
+---
+name: Release
+
 on:
   workflow_dispatch:
     inputs:
-      force_release:
-        description: 'Force release even if version unchanged'
+      force:
+        description: 'Release even if the version was not bumped'
         type: boolean
         default: false
-        required: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  validate-and-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Extract and Validate Version
-        id: version_extraction
-        run: |
-          # Extract version using sed to handle various whitespace scenarios
-          VERSION=$(sed -n 's/.*Version:\s*\([0-9.]\+\).*/\1/p' zuidwest-cache-manager.php | head -1)
-
-          # Validate version format (semantic versioning)
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-            echo "Error: Invalid version format - $VERSION"
-            exit 1
-          fi
-
-          echo "Extracted Version: $VERSION"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Fetch and Validate Latest Tag
-        id: tag_validation
-        run: |
-          # Get latest tag, handling no tags scenario
-          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "")
-          
-          echo "Latest Tag: ${LATEST_TAG:-No previous tag}"
-          echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
-
-      - name: Compare Versions and Decide Release
-        id: release_decision
-        env:
-          FORCE_RELEASE: ${{ github.event.inputs.force_release }}
-        run: |
-          # Compare versions function
-          version_gt() {
-            test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"
-          }
-
-          # Determine if release is needed
-          RELEASE_NEEDED=false
-          
-          if [[ "$FORCE_RELEASE" == "true" ]]; then
-            echo "Forced release triggered"
-            RELEASE_NEEDED=true
-          elif [[ -z "$LATEST_TAG" ]]; then
-            echo "No previous tag found. First release."
-            RELEASE_NEEDED=true
-          elif version_gt "$VERSION" "$LATEST_TAG"; then
-            echo "New version is higher than latest tag"
-            RELEASE_NEEDED=true
-          else
-            echo "No new release needed"
-            RELEASE_NEEDED=false
-          fi
-          
-          echo "Release needed: $RELEASE_NEEDED"
-          echo "RELEASE_NEEDED=$RELEASE_NEEDED" >> $GITHUB_ENV
-
-      - name: Stop if No Release Needed
-        if: env.RELEASE_NEEDED == 'false'
-        run: |
-          echo "Skipping release: No new version detected"
-          exit 0
-
-      - name: Tag the New Version
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git tag ${{ env.VERSION }}
-          git push origin ${{ env.VERSION }}
-          echo "Tag ${{ env.VERSION }} created and pushed"
-
-      - name: Prepare Release Directory
-        run: |
-          mkdir -p release
-          rsync -av --progress . ./release \
-            --exclude release \
-            --exclude .git \
-            --exclude .github \
-            --exclude node_modules \
-            --exclude vendor \
-            --exclude composer.json \
-            --exclude composer.lock \
-            --exclude phpcs.xml \
-            --exclude phpstan.neon \
-            --exclude phpstan-bootstrap.php \
-            --exclude '*.log' \
-            --exclude '.gitignore'
-
-      - name: Set Plugin Name
-        run: |
-          PLUGIN_NAME="zuidwest-cache-manager"
-          echo "PLUGIN_NAME=$PLUGIN_NAME" >> $GITHUB_ENV
-
-      - name: Create Zip Package
-        run: |
-          cd release
-          zip -r "../${{ env.PLUGIN_NAME }}.zip" ./*
-          cd ..
-          ls -la "${{ env.PLUGIN_NAME }}.zip"
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ env.VERSION }} \
-            "${{ env.PLUGIN_NAME }}.zip" \
-            --title "${{ env.VERSION }}" \
-            --generate-notes
-
-      - name: Notify on Failure
-        if: failure()
-        run: |
-          echo "::error::Release process failed. Please check workflow logs."
+  release:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-release.yml@bd7984b073a684089c53524f7c5f52869d91fe0a
+    with:
+      force: ${{ inputs.force }}
+      plugin-slug: zuidwest-cache-manager
+    permissions:
+      contents: write


### PR DESCRIPTION
Smoke-test PR for oszuidwest/.github-templates#23.

Replaces the local 168-line `lint.yml` + `release.yml` with the strict caller workflows pinned to oszuidwest/.github-templates@bd7984b. Goal:

- Verify `wp-ci.yml@bd7984b` runs cleanly on this repo (PHP 8.3 + 8.4 matrix, phpcs, phpstan, plugin-check).
- Verify the `translations` job auto-skips (no `languages/*.pot` here).
- Verify the `Release` workflow can be dispatched (force=false on unchanged 1.7.0 should skip with notice).

Once green, this PR is closed without merging; the real migration lands separately after the templates PR is merged and `v2` is moved.