### PR TITLE
chore: require WordPress 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The plugin purges individual taxonomy feeds (e.g., `/regio/roosendaal/feed/`) bu
 
 ## Requirements
 
-- WordPress 6.8+
+- WordPress 7.0+
 - PHP 8.3+
 - Active Cloudflare account with API access
 - A Cloudflare plan that supports URL prefix purging (verified on Business; file purging works on all plans)

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
 
     <!-- Versions -->
     <config name="testVersion" value="8.3-8.4"/>
-    <config name="minimum_wp_version" value="6.8"/>
+    <config name="minimum_wp_version" value="7.0"/>
 
     <!-- Per-plugin -->
     <config name="text_domain" value="zw-cacheman"/>

--- a/zw-cacheman.php
+++ b/zw-cacheman.php
@@ -7,7 +7,7 @@
  * Author URI: https://www.zuidwesttv.nl
  * License: GPL-3.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
- * Requires at least: 6.8
+ * Requires at least: 7.0
  * Requires PHP: 8.3
  * Text Domain: zw-cacheman
  *


### PR DESCRIPTION
## Summary

- Raise the plugin header and documented minimum WordPress version from 6.8 to 7.0.

## Compatibility audit

- Reviewed the WordPress 6.7, 6.8, 6.9, and 7.0 developer field guides, including the current WordPress 7.0.2 maintenance release.
- Checked the plugin's WordPress API calls against Core functions removed or deprecated through 7.0.
- Ran Plugin Check 2.0.0 in update mode and reviewed the findings for runtime relevance.
- Activated the plugin alongside the complete oszuidwest plugin set on WordPress 7.0.2 and PHP 8.3.32.

The cache invalidation hooks and Cloudflare integration do not use Core APIs changed incompatibly in WordPress 7.

## Verification

- PHPStan
- PHP syntax check
- Plugin Check 2.0.0 review
- Full-set activation on WordPress 7.0.2 / PHP 8.3.32

## References

- [WordPress 6.7 field guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/)
- [WordPress 6.8 field guide](https://make.wordpress.org/core/2025/03/28/wordpress-6-8-field-guide/)
- [WordPress 6.9 field guide](https://make.wordpress.org/core/2025/11/25/wordpress-6-9-field-guide/)
- [WordPress 7.0 field guide](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/)
- [WordPress 7.0.2 release](https://wordpress.org/news/2026/07/wordpress-7-0-2-release/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to raise the minimum supported WordPress version to 7.0+.

* **Chores**
  * Updated plugin compatibility metadata and code-style rules to require WordPress 7.0 or later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->