### PR TITLE
feat: warm cache after purge (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A WordPress plugin for efficient Cloudflare cache management. Immediately purges
 - **URL Prefix Purging**: Uses Cloudflare's prefix purging for archives, automatically clearing paginated pages (v1.1+)
 - **Taxonomy Term Handling**: Purges cache when taxonomy terms are created, edited, or deleted (v1.3+)
 - **SEO Sitemap Purging**: Purges Yoast SEO sitemaps — including the News and Video add-ons — when content changes, with filters to plug in other SEO plugins (v1.8+)
-- **Cache Warming (opt-in)**: After a successful purge, schedules a background WP-Cron refetch of the affected page URLs so the cache is repopulated without a visitor paying the render
+- **Cache Warming (opt-in)**: After a successful purge, queues the affected page URLs for a background WP-Cron refetch so the cache is repopulated without a visitor paying the render
 
 ## How It Works
 
@@ -180,8 +180,44 @@ Configure the plugin under Settings → ZuidWest Cache:
 - **API Key**: Cloudflare API key with cache purging permissions
 - **Batch Size**: URLs per batch (default: 30)
 - **Extra Domains**: Comma-separated list of additional domains to purge (e.g., app.example.com,www.example.com). URLs will be duplicated for these domains.
-- **Warm Cache After Purge**: When enabled, schedules a background WP-Cron refetch of purged page URLs (not prefix or REST API URLs), so the CDN/origin cache is repopulated by the server instead of by a visitor. Runs after a successful purge; timing follows WP-Cron. Off by default.
+- **Warm Cache After Purge**: When enabled, queues purged page URLs (not prefix or REST API URLs) for a background refetch, drained in small batches by the every-minute WP-Cron job, so the CDN/origin cache is repopulated by the server instead of by a visitor. Runs after a successful purge; timing follows WP-Cron. Off by default.
 - **Debug Mode**: Enable logging
+
+### Authenticated Cloudflare WAF exception
+
+Cache warming only populates the Cloudflare edge when the server reaches the site's public URL through Cloudflare. If a WAF rule or Super Bot Fight Mode blocks these requests, configure a private per-installation token before creating an exception. Never create a skip rule based only on the public `X-ZW-Cache-Warm: 1` header.
+
+Generate a 32-byte token:
+
+```bash
+openssl rand -hex 32
+```
+
+Provide it through the server environment and expose it to WordPress in `wp-config.php`:
+
+```php
+define(
+    'ZW_CACHEMAN_WARM_TOKEN',
+    getenv( 'ZW_CACHEMAN_WARM_TOKEN' ) ?: ''
+);
+```
+
+The token must contain exactly 64 hexadecimal characters. It is never stored in the WordPress database or displayed by the plugin; the settings page only reports whether a valid token is configured.
+
+After sending one warming request, identify the actual server egress IP and blocking rule in Cloudflare Security Events. Create the narrowest possible exception, for example:
+
+```text
+(
+  http.request.method eq "GET"
+  and ip.src in {203.0.113.10}
+  and any(
+    http.request.headers["x-zw-cache-warm-token"][*]
+      eq "<private-64-character-token>"
+  )
+)
+```
+
+Replace the example IP and token with the server's dedicated static egress IP and configured token. Keep match logging enabled and skip only the specific managed rule that caused the false positive, or only Super Bot Fight Mode when applicable. Do not skip all custom rules, all managed rules, or rate limiting. Do not use an IP-based exception with a shared or dynamic egress IP. Cloudflare Bot Fight Mode cannot be skipped with a custom WAF rule.
 
 ## Developer Filters
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The warmer does not queue:
 - `Prefix` purge items. A prefix purge may invalidate an entire archive and its pagination, but the warmer only fetches an archive landing page when that URL is also present as a separate `File` item; it does not fetch `/page/2/` and later pages.
 - WordPress REST API URLs
 
-Pending URLs are deduplicated in a queue capped at 500 entries. If the same URL is purged again while an earlier fetch is in flight, the newer purge remains as a separate queue generation. The every-minute WP-Cron job claims at most five warming requests per run, after purge processing. Each request is an unauthenticated public `GET` unless a valid WAF warm token is configured. Transport failures move to the queue tail for a later retry; any HTTP response, including `4xx` or `5xx`, is considered terminal and removes only the fetched generation. Actual timing depends on WP-Cron traffic.
+Pending URLs are deduplicated in a queue capped at 500 entries. The every-minute WP-Cron job fetches at most five queued URLs per run, after purge processing. Each request is an unauthenticated public `GET` unless a valid WAF warm token is configured. Transport failures move to the queue tail for a later retry; any HTTP response, including `4xx` or `5xx`, is considered terminal and dequeues the URL. Warming is best-effort: queue updates are not atomic, so under concurrent purges or overlapping cron runs a URL can occasionally be warmed more than once or a pending URL can be lost — a visitor then warms that page instead. Actual timing depends on WP-Cron traffic.
 
 ### Authenticated Cloudflare WAF exception
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The warmer does not queue:
 - `Prefix` purge items. A prefix purge may invalidate an entire archive and its pagination, but the warmer only fetches an archive landing page when that URL is also present as a separate `File` item; it does not fetch `/page/2/` and later pages.
 - WordPress REST API URLs
 
-Eligible URLs are deduplicated in a queue capped at 500 entries. The every-minute WP-Cron job processes at most five warming requests per run, after purge processing. Each request is an unauthenticated public `GET` unless a valid WAF warm token is configured. Transport failures remain queued for a retry; any HTTP response, including `4xx` or `5xx`, is considered terminal and removed from the queue. Actual timing depends on WP-Cron traffic.
+Pending URLs are deduplicated in a queue capped at 500 entries. If the same URL is purged again while an earlier fetch is in flight, the newer purge remains as a separate queue generation. The every-minute WP-Cron job claims at most five warming requests per run, after purge processing. Each request is an unauthenticated public `GET` unless a valid WAF warm token is configured. Transport failures move to the queue tail for a later retry; any HTTP response, including `4xx` or `5xx`, is considered terminal and removes only the fetched generation. Actual timing depends on WP-Cron traffic.
 
 ### Authenticated Cloudflare WAF exception
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A WordPress plugin for efficient Cloudflare cache management. Immediately purges
 - **URL Prefix Purging**: Uses Cloudflare's prefix purging for archives, automatically clearing paginated pages (v1.1+)
 - **Taxonomy Term Handling**: Purges cache when taxonomy terms are created, edited, or deleted (v1.3+)
 - **SEO Sitemap Purging**: Purges Yoast SEO sitemaps — including the News and Video add-ons — when content changes, with filters to plug in other SEO plugins (v1.8+)
+- **Cache Warming (opt-in)**: After a purge, re-fetches the affected page URLs in a background cron event so the cache is repopulated before the next visitor arrives
 
 ## How It Works
 
@@ -179,6 +180,7 @@ Configure the plugin under Settings → ZuidWest Cache:
 - **API Key**: Cloudflare API key with cache purging permissions
 - **Batch Size**: URLs per batch (default: 30)
 - **Extra Domains**: Comma-separated list of additional domains to purge (e.g., app.example.com,www.example.com). URLs will be duplicated for these domains.
+- **Warm Cache After Purge**: When enabled, re-fetches purged page URLs (not prefix or REST API URLs) in a background cron event, so the CDN/origin cache is repopulated before the next visitor hits a cold page. Off by default.
 - **Debug Mode**: Enable logging
 
 ## Developer Filters

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A WordPress plugin for efficient Cloudflare cache management. Immediately purges
 - **URL Prefix Purging**: Uses Cloudflare's prefix purging for archives, automatically clearing paginated pages (v1.1+)
 - **Taxonomy Term Handling**: Purges cache when taxonomy terms are created, edited, or deleted (v1.3+)
 - **SEO Sitemap Purging**: Purges Yoast SEO sitemaps — including the News and Video add-ons — when content changes, with filters to plug in other SEO plugins (v1.8+)
-- **Cache Warming (opt-in)**: After a purge, re-fetches the affected page URLs in a background cron event so the cache is repopulated before the next visitor arrives
+- **Cache Warming (opt-in)**: After a successful purge, schedules a background WP-Cron refetch of the affected page URLs so the cache is repopulated without a visitor paying the render
 
 ## How It Works
 
@@ -180,7 +180,7 @@ Configure the plugin under Settings → ZuidWest Cache:
 - **API Key**: Cloudflare API key with cache purging permissions
 - **Batch Size**: URLs per batch (default: 30)
 - **Extra Domains**: Comma-separated list of additional domains to purge (e.g., app.example.com,www.example.com). URLs will be duplicated for these domains.
-- **Warm Cache After Purge**: When enabled, re-fetches purged page URLs (not prefix or REST API URLs) in a background cron event, so the CDN/origin cache is repopulated before the next visitor hits a cold page. Off by default.
+- **Warm Cache After Purge**: When enabled, schedules a background WP-Cron refetch of purged page URLs (not prefix or REST API URLs), so the CDN/origin cache is repopulated by the server instead of by a visitor. Runs after a successful purge; timing follows WP-Cron. Off by default.
 - **Debug Mode**: Enable logging
 
 ## Developer Filters

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Configure the plugin under Settings → ZuidWest Cache:
 
 ### Authenticated Cloudflare WAF exception
 
-Cache warming only populates the Cloudflare edge when the server reaches the site's public URL through Cloudflare. If a WAF rule or Super Bot Fight Mode blocks these requests, configure a private per-installation token before creating an exception. Never create a skip rule based only on the public `X-ZW-Cache-Warm: 1` header.
+Cache warming only populates the Cloudflare edge when the server reaches the site's public URL through Cloudflare. If a WAF rule or Super Bot Fight Mode blocks these requests, configure a private per-installation token before creating an exception. Never create a skip rule based only on the `ZWCacheMan-Warmer` user agent — it is trivially spoofable.
 
 Generate a 32-byte token:
 

--- a/README.md
+++ b/README.md
@@ -175,13 +175,31 @@ Without URL prefix purging, you would need to individually purge each pagination
 4. Activate the plugin after installation completes
 
 ### Configuration
+
 Configure the plugin under Settings → ZuidWest Cache:
+
 - **Zone ID**: Cloudflare Zone ID
 - **API Key**: Cloudflare API key with cache purging permissions
 - **Batch Size**: URLs per batch (default: 30)
 - **Extra Domains**: Comma-separated list of additional domains to purge (e.g., app.example.com,www.example.com). URLs will be duplicated for these domains.
-- **Warm Cache After Purge**: When enabled, queues purged page URLs (not prefix or REST API URLs) for a background refetch, drained in small batches by the every-minute WP-Cron job, so the CDN/origin cache is repopulated by the server instead of by a visitor. Runs after a successful purge; timing follows WP-Cron. Off by default.
+- **Warm Cache After Purge**: When enabled, queues eligible exact-URL purges for a background refetch, so the CDN/origin cache is repopulated by the server instead of by a visitor. See [Cache warming selection](#cache-warming-selection) for the exact rules. Off by default.
 - **Debug Mode**: Enable logging
+
+### Cache warming selection
+
+Cache warming is event-driven and does not crawl the whole site. After a successful Cloudflare purge, the warmer queues every purge item of type `File` except URLs under the WordPress REST API path. This includes exact URLs such as:
+
+- Post and page permalinks, the home page, and archive landing pages when they are also emitted as a `File` purge
+- Site, post-comment, term, and author feeds
+- Exact sitemap URLs such as `sitemap_index.xml` and the first page of a post-type, taxonomy, author, news, or video sitemap
+- Eligible copies of these URLs for any configured extra domains
+
+The warmer does not queue:
+
+- `Prefix` purge items. A prefix purge may invalidate an entire archive and its pagination, but the warmer only fetches an archive landing page when that URL is also present as a separate `File` item; it does not fetch `/page/2/` and later pages.
+- WordPress REST API URLs
+
+Eligible URLs are deduplicated in a queue capped at 500 entries. The every-minute WP-Cron job processes at most five warming requests per run, after purge processing. Each request is an unauthenticated public `GET` unless a valid WAF warm token is configured. Transport failures remain queued for a retry; any HTTP response, including `4xx` or `5xx`, is considered terminal and removed from the queue. Actual timing depends on WP-Cron traffic.
 
 ### Authenticated Cloudflare WAF exception
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -19,14 +19,15 @@ readonly class CachemanAdmin {
 	/**
 	 * Default settings
 	 *
-	 * @var array{zone_id: string, api_key: string, batch_size: int, debug_mode: bool, extra_domains: string}
+	 * @var array{zone_id: string, api_key: string, batch_size: int, debug_mode: bool, extra_domains: string, enable_warming: bool}
 	 */
 	public const array DEFAULT_SETTINGS = [
-		'zone_id'       => '',
-		'api_key'       => '',
-		'batch_size'    => 30,
-		'debug_mode'    => false,
-		'extra_domains' => '',
+		'zone_id'        => '',
+		'api_key'        => '',
+		'batch_size'     => 30,
+		'debug_mode'     => false,
+		'extra_domains'  => '',
+		'enable_warming' => false,
 	];
 
 	/**
@@ -150,6 +151,18 @@ readonly class CachemanAdmin {
 		);
 
 		add_settings_field(
+			'enable_warming',
+			__( 'Warm Cache After Purge', 'zw-cacheman' ),
+			$this->render_field( ... ),
+			'zw_cacheman_settings',
+			'zw_cacheman_main_section',
+			[
+				'name' => 'enable_warming',
+				'type' => 'checkbox',
+			]
+		);
+
+		add_settings_field(
 			'debug_mode',
 			__( 'Debug Mode', 'zw-cacheman' ),
 			$this->render_field( ... ),
@@ -215,7 +228,7 @@ readonly class CachemanAdmin {
 	 * Sanitize settings
 	 *
 	 * @param array<string, mixed> $input Raw input values.
-	 * @return array{zone_id: string, api_key: string, batch_size: int, debug_mode: bool, extra_domains: string} Sanitized values.
+	 * @return array{zone_id: string, api_key: string, batch_size: int, debug_mode: bool, extra_domains: string, enable_warming: bool} Sanitized values.
 	 */
 	public function sanitize_settings( array $input ): array {
 		$sanitized    = [];
@@ -239,8 +252,9 @@ readonly class CachemanAdmin {
 			);
 		}
 
-		// Sanitize checkbox to boolean.
-		$sanitized['debug_mode'] = isset( $input['debug_mode'] ) ? true : false;
+		// Sanitize checkboxes to boolean.
+		$sanitized['debug_mode']     = isset( $input['debug_mode'] );
+		$sanitized['enable_warming'] = isset( $input['enable_warming'] );
 
 		// Sanitize extra domains and validate each as a hostname.
 		$extra_domains_input = isset( $input['extra_domains'] ) ? sanitize_text_field( $input['extra_domains'] ) : '';

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -246,9 +246,12 @@ readonly class CachemanAdmin {
 		}
 
 		printf(
-			'<p class="description">%s <code>ZW_CACHEMAN_WARM_TOKEN</code> %s</p>',
-			esc_html__( 'Define', 'zw-cacheman' ),
-			esc_html__( 'in wp-config.php as exactly 64 hexadecimal characters to authenticate Cloudflare WAF exceptions.', 'zw-cacheman' )
+			'<p class="description">%s</p>',
+			sprintf(
+				/* translators: %s: the ZW_CACHEMAN_WARM_TOKEN constant name */
+				esc_html__( 'Define %s in wp-config.php as exactly 64 hexadecimal characters to authenticate Cloudflare WAF exceptions.', 'zw-cacheman' ),
+				'<code>ZW_CACHEMAN_WARM_TOKEN</code>'
+			)
 		);
 	}
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -163,6 +163,14 @@ readonly class CachemanAdmin {
 		);
 
 		add_settings_field(
+			'warm_token_status',
+			__( 'WAF Warm Token Configured', 'zw-cacheman' ),
+			$this->render_warm_token_status( ... ),
+			'zw_cacheman_settings',
+			'zw_cacheman_main_section'
+		);
+
+		add_settings_field(
 			'debug_mode',
 			__( 'Debug Mode', 'zw-cacheman' ),
 			$this->render_field( ... ),
@@ -222,6 +230,26 @@ readonly class CachemanAdmin {
 			),
 			default => null
 		};
+	}
+
+	/**
+	 * Render the WAF warm-token configuration status without exposing its value.
+	 */
+	public function render_warm_token_status(): void {
+		$configured = CachemanWarmer::has_valid_waf_token();
+
+		echo '<strong>' . esc_html( $configured ? __( 'Yes', 'zw-cacheman' ) : __( 'No', 'zw-cacheman' ) ) . '</strong>';
+
+		if ( $configured ) {
+			echo '<p class="description">' . esc_html__( 'A valid token is configured in wp-config.php.', 'zw-cacheman' ) . '</p>';
+			return;
+		}
+
+		printf(
+			'<p class="description">%s <code>ZW_CACHEMAN_WARM_TOKEN</code> %s</p>',
+			esc_html__( 'Define', 'zw-cacheman' ),
+			esc_html__( 'in wp-config.php as exactly 64 hexadecimal characters to authenticate Cloudflare WAF exceptions.', 'zw-cacheman' )
+		);
 	}
 
 	/**

--- a/includes/api.php
+++ b/includes/api.php
@@ -213,8 +213,23 @@ readonly class CachemanAPI {
 	 * @return bool Success status
 	 */
 	public function process_purge_items( array $purge_items ): bool {
+		$results = $this->process_purge_items_by_type( $purge_items );
+
+		return $results[ PurgeType::File->value ] && $results[ PurgeType::Prefix->value ];
+	}
+
+	/**
+	 * Process purge items and preserve the result for each purge type.
+	 *
+	 * @param array<array{type: PurgeType, url: string}> $purge_items Items to purge.
+	 * @return array{file: bool, prefix: bool} Success status keyed by purge type.
+	 */
+	public function process_purge_items_by_type( array $purge_items ): array {
 		if ( empty( $purge_items ) ) {
-			return true;
+			return [
+				PurgeType::File->value   => true,
+				PurgeType::Prefix->value => true,
+			];
 		}
 
 		$this->logger->debug( 'API', 'Processing ' . count( $purge_items ) . ' purge items' );
@@ -253,7 +268,10 @@ readonly class CachemanAPI {
 			}
 		}
 
-		return $files_success && $prefixes_success;
+		return [
+			PurgeType::File->value   => $files_success,
+			PurgeType::Prefix->value => $prefixes_success,
+		];
 	}
 
 	/**

--- a/includes/cache-manager.php
+++ b/includes/cache-manager.php
@@ -273,12 +273,6 @@ readonly class CachemanManager {
 		// Purge first, then drain the warm queue so pages are re-fetched
 		// after their cache entries are gone.
 		$this->warmer->process_queue();
-
-		// Ensure WP-Cron is still scheduled.
-		if ( ! wp_next_scheduled( ZW_CACHEMAN_CRON_HOOK ) ) {
-			wp_schedule_event( time(), 'every_minute', ZW_CACHEMAN_CRON_HOOK );
-			$this->logger->debug( 'Manager', 'Re-scheduled missing cron job.' );
-		}
 	}
 
 	/**

--- a/includes/cache-manager.php
+++ b/includes/cache-manager.php
@@ -19,14 +19,16 @@ readonly class CachemanManager {
 	/**
 	 * Constructor
 	 *
-	 * @param CachemanAPI       $api       The API handler instance.
+	 * @param CachemanAPI       $api        The API handler instance.
 	 * @param CachemanUrlDelver $url_delver The URL delver instance.
 	 * @param CachemanLogger    $logger     The logger instance.
+	 * @param CachemanWarmer    $warmer     The cache warmer instance.
 	 */
 	public function __construct(
 		private CachemanAPI $api,
 		private CachemanUrlDelver $url_delver,
-		private CachemanLogger $logger
+		private CachemanLogger $logger,
+		private CachemanWarmer $warmer
 	) {
 		// Hook into post status transitions.
 		add_action( 'transition_post_status', $this->handle_post_status_change( ... ), 10, 3 );
@@ -201,7 +203,9 @@ readonly class CachemanManager {
 
 		$this->logger->debug( 'Manager', 'Processing ' . count( $items ) . ' ' . $description );
 
-		if ( ! $this->api->process_purge_items( $items ) ) {
+		if ( $this->api->process_purge_items( $items ) ) {
+			$this->warmer->schedule( $items );
+		} else {
 			$this->logger->error( 'Manager', 'Failed to process ' . $description );
 			$this->queue_purge_items( $items );
 		}
@@ -273,6 +277,7 @@ readonly class CachemanManager {
 			// Update the queue with remaining items (autoload disabled for performance).
 			update_option( ZW_CACHEMAN_QUEUE, $remaining_items, false );
 			$this->logger->debug( 'Manager', 'Successfully processed batch. ' . count( $remaining_items ) . ' items remaining in queue.' );
+			$this->warmer->schedule( $items_to_process );
 		} else {
 			$this->logger->error( 'Manager', 'Failed to process batch of ' . count( $items_to_process ) . ' items. Will retry next run.' );
 		}

--- a/includes/cache-manager.php
+++ b/includes/cache-manager.php
@@ -203,12 +203,25 @@ readonly class CachemanManager {
 
 		$this->logger->debug( 'Manager', 'Processing ' . count( $items ) . ' ' . $description );
 
-		if ( $this->api->process_purge_items( $items ) ) {
-			$this->warmer->schedule( $items );
-		} else {
+		if ( ! $this->purge_items( $items ) ) {
 			$this->logger->error( 'Manager', 'Failed to process ' . $description );
 			$this->queue_purge_items( $items );
 		}
+	}
+
+	/**
+	 * Purge items via the API, queueing them for cache warming on success.
+	 *
+	 * @param array<array{type: PurgeType, url: string}> $items Items to purge.
+	 * @return bool Whether the purge succeeded.
+	 */
+	private function purge_items( array $items ): bool {
+		if ( ! $this->api->process_purge_items( $items ) ) {
+			return false;
+		}
+
+		$this->warmer->enqueue( $items );
+		return true;
 	}
 
 	/**
@@ -270,14 +283,10 @@ readonly class CachemanManager {
 
 		$this->logger->debug( 'Manager', 'Processing ' . count( $items_to_process ) . ' items (' . count( $remaining_items ) . ' remaining)' );
 
-		// Process the batch using the API's process_purge_items method.
-		$success = $this->api->process_purge_items( $items_to_process );
-
-		if ( $success ) {
+		if ( $this->purge_items( $items_to_process ) ) {
 			// Update the queue with remaining items (autoload disabled for performance).
 			update_option( ZW_CACHEMAN_QUEUE, $remaining_items, false );
 			$this->logger->debug( 'Manager', 'Successfully processed batch. ' . count( $remaining_items ) . ' items remaining in queue.' );
-			$this->warmer->schedule( $items_to_process );
 		} else {
 			$this->logger->error( 'Manager', 'Failed to process batch of ' . count( $items_to_process ) . ' items. Will retry next run.' );
 		}

--- a/includes/cache-manager.php
+++ b/includes/cache-manager.php
@@ -203,9 +203,10 @@ readonly class CachemanManager {
 
 		$this->logger->debug( 'Manager', 'Processing ' . count( $items ) . ' ' . $description );
 
-		if ( ! $this->purge_items( $items ) ) {
-			$this->logger->error( 'Manager', 'Failed to process ' . $description );
-			$this->queue_purge_items( $items );
+		$failed_items = $this->purge_items( $items );
+		if ( ! empty( $failed_items ) ) {
+			$this->logger->error( 'Manager', 'Failed to process ' . count( $failed_items ) . ' ' . $description );
+			$this->queue_purge_items( $failed_items );
 		}
 	}
 
@@ -213,15 +214,26 @@ readonly class CachemanManager {
 	 * Purge items via the API, queueing them for cache warming on success.
 	 *
 	 * @param array<array{type: PurgeType, url: string}> $items Items to purge.
-	 * @return bool Whether the purge succeeded.
+	 * @return array<array{type: PurgeType, url: string}> Items whose purge failed.
 	 */
-	private function purge_items( array $items ): bool {
-		if ( ! $this->api->process_purge_items( $items ) ) {
-			return false;
-		}
+	private function purge_items( array $items ): array {
+		$results = $this->api->process_purge_items_by_type( $items );
 
-		$this->warmer->enqueue( $items );
-		return true;
+		$this->warmer->enqueue(
+			array_values(
+				array_filter(
+					$items,
+					static fn ( array $item ): bool => PurgeType::File === $item['type'] && $results[ PurgeType::File->value ]
+				)
+			)
+		);
+
+		return array_values(
+			array_filter(
+				$items,
+				static fn ( array $item ): bool => ! $results[ $item['type']->value ]
+			)
+		);
 	}
 
 	/**
@@ -294,10 +306,18 @@ readonly class CachemanManager {
 
 		$this->logger->debug( 'Manager', 'Processing ' . count( $items_to_process ) . ' items (' . count( $remaining_items ) . ' remaining)' );
 
-		if ( $this->purge_items( $items_to_process ) ) {
+		$failed_items = $this->purge_items( $items_to_process );
+		if ( empty( $failed_items ) ) {
 			// Update the queue with remaining items (autoload disabled for performance).
 			update_option( ZW_CACHEMAN_QUEUE, $remaining_items, false );
 			$this->logger->debug( 'Manager', 'Successfully processed batch. ' . count( $remaining_items ) . ' items remaining in queue.' );
+		} elseif ( count( $failed_items ) < count( $items_to_process ) ) {
+			$next_queue = array_merge( $failed_items, $remaining_items );
+			update_option( ZW_CACHEMAN_QUEUE, $next_queue, false );
+			$this->logger->error(
+				'Manager',
+				'Failed to process ' . count( $failed_items ) . ' of ' . count( $items_to_process ) . ' items. Failed items will retry next run.'
+			);
 		} else {
 			$this->logger->error( 'Manager', 'Failed to process batch of ' . count( $items_to_process ) . ' items. Will retry next run.' );
 		}

--- a/includes/cache-manager.php
+++ b/includes/cache-manager.php
@@ -268,6 +268,23 @@ readonly class CachemanManager {
 	 * Process the queue - called by WP-Cron
 	 */
 	public function process_queue(): void {
+		$this->process_purge_queue();
+
+		// Purge first, then drain the warm queue so pages are re-fetched
+		// after their cache entries are gone.
+		$this->warmer->process_queue();
+
+		// Ensure WP-Cron is still scheduled.
+		if ( ! wp_next_scheduled( ZW_CACHEMAN_CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'every_minute', ZW_CACHEMAN_CRON_HOOK );
+			$this->logger->debug( 'Manager', 'Re-scheduled missing cron job.' );
+		}
+	}
+
+	/**
+	 * Purge a batch of queued items.
+	 */
+	private function process_purge_queue(): void {
 		$queue = get_option( ZW_CACHEMAN_QUEUE, [] );
 		if ( empty( $queue ) ) {
 			$this->logger->debug( 'Manager', 'Queue is empty. Nothing to process.' );
@@ -289,12 +306,6 @@ readonly class CachemanManager {
 			$this->logger->debug( 'Manager', 'Successfully processed batch. ' . count( $remaining_items ) . ' items remaining in queue.' );
 		} else {
 			$this->logger->error( 'Manager', 'Failed to process batch of ' . count( $items_to_process ) . ' items. Will retry next run.' );
-		}
-
-		// Ensure WP-Cron is still scheduled.
-		if ( ! wp_next_scheduled( ZW_CACHEMAN_CRON_HOOK ) ) {
-			wp_schedule_event( time(), 'every_minute', ZW_CACHEMAN_CRON_HOOK );
-			$this->logger->debug( 'Manager', 'Re-scheduled missing cron job.' );
 		}
 	}
 }

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -35,6 +35,19 @@ readonly class CachemanWarmer {
 	private const WARM_QUEUE_MAX = 500;
 
 	/**
+	 * Option used as an atomic lock for warm-queue mutations.
+	 */
+	private const WARM_QUEUE_LOCK = 'zw_cacheman_warm_queue_lock';
+
+	/**
+	 * Lock lifetime and retry interval. Queue mutations are local option
+	 * updates, so the lock should normally be held for only milliseconds.
+	 */
+	private const WARM_QUEUE_LOCK_TTL_SECONDS        = 30;
+	private const WARM_QUEUE_LOCK_RETRY_MICROSECONDS = 50_000;
+	private const WARM_QUEUE_LOCK_ATTEMPTS           = 40;
+
+	/**
 	 * Header used to authenticate cache-warming requests at Cloudflare.
 	 */
 	private const WARM_TOKEN_HEADER = 'X-ZW-Cache-Warm-Token';
@@ -74,17 +87,21 @@ readonly class CachemanWarmer {
 			return;
 		}
 
-		$queue = array_values( array_unique( array_merge( $this->read_queue(), $urls ) ) );
+		$this->update_queue(
+			function ( array $queue ) use ( $urls ): array {
+				$queue = array_values( array_unique( array_merge( $queue, $urls ) ) );
 
-		if ( count( $queue ) > self::WARM_QUEUE_MAX ) {
-			$queue = array_slice( $queue, -self::WARM_QUEUE_MAX );
-			if ( false === get_transient( 'zw_cacheman_warm_queue_overflow' ) ) {
-				$this->logger->error( 'Warmer', 'Warm queue exceeded ' . self::WARM_QUEUE_MAX . '; dropped oldest URLs' );
-				set_transient( 'zw_cacheman_warm_queue_overflow', true, 5 * MINUTE_IN_SECONDS );
+				if ( count( $queue ) > self::WARM_QUEUE_MAX ) {
+					$queue = array_slice( $queue, -self::WARM_QUEUE_MAX );
+					if ( false === get_transient( 'zw_cacheman_warm_queue_overflow' ) ) {
+						$this->logger->error( 'Warmer', 'Warm queue exceeded ' . self::WARM_QUEUE_MAX . '; dropped oldest URLs' );
+						set_transient( 'zw_cacheman_warm_queue_overflow', true, 5 * MINUTE_IN_SECONDS );
+					}
+				}
+
+				return $queue;
 			}
-		}
-
-		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
+		);
 	}
 
 	/**
@@ -92,14 +109,14 @@ readonly class CachemanWarmer {
 	 * purge pass. Keeps each WP-Cron pass short instead of processing a whole
 	 * burst at once. Items are removed only after a successful warm, and the
 	 * queue is re-read before writing, so a crash mid-batch does not lose
-	 * failed URLs and (with a persistent object cache) concurrently queued
-	 * URLs are preserved.
+	 * failed URLs and the shared mutation lock preserves concurrently queued
+	 * URLs.
 	 */
 	public function process_queue(): void {
 		if ( ! $this->enabled ) {
 			// Warming was turned off; drop any URLs still parked in the queue.
 			if ( [] !== $this->read_queue() ) {
-				delete_option( ZW_CACHEMAN_WARM_QUEUE );
+				$this->clear_queue();
 			}
 			return;
 		}
@@ -118,8 +135,9 @@ readonly class CachemanWarmer {
 
 		// Re-read and drop only the URLs we warmed; failed fetches stay
 		// queued for the next run.
-		$queue = array_values( array_diff( $this->read_queue(), $warmed ) );
-		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
+		$this->update_queue(
+			static fn ( array $current_queue ): array => array_values( array_diff( $current_queue, $warmed ) )
+		);
 	}
 
 	/**
@@ -167,6 +185,108 @@ readonly class CachemanWarmer {
 	private function read_queue(): array {
 		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
 		return is_array( $queue ) ? $queue : [];
+	}
+
+	/**
+	 * Delete the warm queue under the shared option lock.
+	 */
+	private function clear_queue(): void {
+		$lock = $this->acquire_queue_lock();
+		if ( null === $lock ) {
+			return;
+		}
+
+		try {
+			delete_option( ZW_CACHEMAN_WARM_QUEUE );
+		} finally {
+			$this->release_queue_lock( $lock );
+		}
+	}
+
+	/**
+	 * Atomically mutate the warm queue under the shared option lock.
+	 *
+	 * @param callable(array<string>): array<string> $update Queue mutation.
+	 * @return bool Whether the queue was updated.
+	 */
+	private function update_queue( callable $update ): bool {
+		$lock = $this->acquire_queue_lock();
+		if ( null === $lock ) {
+			return false;
+		}
+
+		try {
+			update_option( ZW_CACHEMAN_WARM_QUEUE, $update( $this->read_queue() ), false );
+			return true;
+		} finally {
+			$this->release_queue_lock( $lock );
+		}
+	}
+
+	/**
+	 * Acquire the shared warm-queue lock.
+	 *
+	 * The add_option() function provides the atomic uncontended path. An
+	 * expired lock is replaced with a compare-and-swap update so only one
+	 * waiter can steal it.
+	 *
+	 * @return string|null Lock value owned by this request, or null on timeout.
+	 */
+	private function acquire_queue_lock(): ?string {
+		global $wpdb;
+
+		$lock = ( time() + self::WARM_QUEUE_LOCK_TTL_SECONDS ) . '|' . wp_generate_uuid4();
+
+		for ( $attempt = 0; $attempt < self::WARM_QUEUE_LOCK_ATTEMPTS; $attempt++ ) {
+			if ( add_option( self::WARM_QUEUE_LOCK, $lock, '', false ) ) {
+				return $lock;
+			}
+
+			$current_lock = get_option( self::WARM_QUEUE_LOCK, '' );
+			if ( is_string( $current_lock ) && (int) $current_lock < time() ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- A conditional update is required for atomic stale-lock recovery.
+				$updated = $wpdb->update(
+					$wpdb->options,
+					[ 'option_value' => $lock ],
+					[
+						'option_name'  => self::WARM_QUEUE_LOCK,
+						'option_value' => $current_lock,
+					],
+					[ '%s' ],
+					[ '%s', '%s' ]
+				);
+				wp_cache_delete( self::WARM_QUEUE_LOCK, 'options' );
+
+				if ( 1 === $updated ) {
+					return $lock;
+				}
+			}
+
+			usleep( self::WARM_QUEUE_LOCK_RETRY_MICROSECONDS );
+		}
+
+		$this->logger->error( 'Warmer', 'Could not acquire the warm queue lock; queue update skipped' );
+		return null;
+	}
+
+	/**
+	 * Release the lock only when it is still owned by this request.
+	 *
+	 * @param string $lock Lock value returned by acquire_queue_lock().
+	 */
+	private function release_queue_lock( string $lock ): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- The owner check prevents an expired lock from releasing its replacement.
+		$wpdb->delete(
+			$wpdb->options,
+			[
+				'option_name'  => self::WARM_QUEUE_LOCK,
+				'option_value' => $lock,
+			],
+			[ '%s', '%s' ]
+		);
+		wp_cache_delete( self::WARM_QUEUE_LOCK, 'options' );
 	}
 
 	/**

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -35,17 +35,17 @@ readonly class CachemanWarmer {
 	private const WARM_QUEUE_MAX = 500;
 
 	/**
-	 * Option used as an atomic lock for warm-queue mutations.
-	 */
-	private const WARM_QUEUE_LOCK = 'zw_cacheman_warm_queue_lock';
-
-	/**
 	 * Lock lifetime and retry interval. Queue mutations are local option
 	 * updates, so the lock should normally be held for only milliseconds.
 	 */
 	private const WARM_QUEUE_LOCK_TTL_SECONDS        = 30;
 	private const WARM_QUEUE_LOCK_RETRY_MICROSECONDS = 50_000;
 	private const WARM_QUEUE_LOCK_ATTEMPTS           = 40;
+
+	/**
+	 * Time before an interrupted warm claim can be retried.
+	 */
+	private const WARM_CLAIM_TTL_SECONDS = 120;
 
 	/**
 	 * Header used to authenticate cache-warming requests at Cloudflare.
@@ -89,13 +89,29 @@ readonly class CachemanWarmer {
 
 		$this->update_queue(
 			function ( array $queue ) use ( $urls ): array {
-				$queue = array_values( array_unique( array_merge( $queue, $urls ) ) );
+				$pending_urls = [];
+				$now          = time();
+
+				foreach ( $queue as $entry ) {
+					if ( $entry['claimed_until'] <= $now ) {
+						$pending_urls[ $entry['url'] ] = true;
+					}
+				}
+
+				foreach ( $urls as $url ) {
+					if ( isset( $pending_urls[ $url ] ) ) {
+						continue;
+					}
+
+					$queue[]              = self::new_queue_entry( $url );
+					$pending_urls[ $url ] = true;
+				}
 
 				if ( count( $queue ) > self::WARM_QUEUE_MAX ) {
 					$queue = array_slice( $queue, -self::WARM_QUEUE_MAX );
-					if ( false === get_transient( 'zw_cacheman_warm_queue_overflow' ) ) {
+					if ( false === get_transient( ZW_CACHEMAN_WARM_QUEUE_OVERFLOW ) ) {
 						$this->logger->error( 'Warmer', 'Warm queue exceeded ' . self::WARM_QUEUE_MAX . '; dropped oldest URLs' );
-						set_transient( 'zw_cacheman_warm_queue_overflow', true, 5 * MINUTE_IN_SECONDS );
+						set_transient( ZW_CACHEMAN_WARM_QUEUE_OVERFLOW, true, 5 * MINUTE_IN_SECONDS );
 					}
 				}
 
@@ -121,23 +137,22 @@ readonly class CachemanWarmer {
 			return;
 		}
 
-		$queue = $this->read_queue();
-		if ( empty( $queue ) ) {
+		$batch = $this->claim_batch();
+		if ( empty( $batch ) ) {
 			return;
 		}
 
 		$warmed = [];
-		foreach ( array_slice( $queue, 0, self::WARM_BATCH_SIZE ) as $url ) {
-			if ( $this->warm( $url ) ) {
-				$warmed[] = $url;
+		$failed = [];
+		foreach ( $batch as $entry ) {
+			if ( $this->warm( $entry['url'] ) ) {
+				$warmed[] = $entry['id'];
+			} else {
+				$failed[] = $entry['id'];
 			}
 		}
 
-		// Re-read and drop only the URLs we warmed; failed fetches stay
-		// queued for the next run.
-		$this->update_queue(
-			static fn ( array $current_queue ): array => array_values( array_diff( $current_queue, $warmed ) )
-		);
+		$this->acknowledge_batch( $warmed, $failed );
 	}
 
 	/**
@@ -178,13 +193,127 @@ readonly class CachemanWarmer {
 	}
 
 	/**
-	 * Read the warm queue option, normalizing a corrupt value to an empty list.
+	 * Read and normalize the warm queue.
 	 *
-	 * @return array<string> Queued URLs.
+	 * Legacy string entries are upgraded in memory and persisted by the next
+	 * queue mutation.
+	 *
+	 * @return array<array{id: string, url: string, claimed_until: int}> Queue entries.
 	 */
 	private function read_queue(): array {
 		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
-		return is_array( $queue ) ? $queue : [];
+		if ( ! is_array( $queue ) ) {
+			return [];
+		}
+
+		$normalized = [];
+		foreach ( $queue as $entry ) {
+			if ( is_string( $entry ) && '' !== $entry ) {
+				$normalized[] = self::new_queue_entry( $entry );
+				continue;
+			}
+
+			if ( ! is_array( $entry ) || ! isset( $entry['url'] ) || ! is_string( $entry['url'] ) || '' === $entry['url'] ) {
+				continue;
+			}
+
+			$normalized[] = [
+				'id'            => isset( $entry['id'] ) && is_string( $entry['id'] ) && '' !== $entry['id'] ? $entry['id'] : wp_generate_uuid4(),
+				'url'           => $entry['url'],
+				'claimed_until' => isset( $entry['claimed_until'] ) ? (int) $entry['claimed_until'] : 0,
+			];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Create a new pending queue generation.
+	 *
+	 * @param string $url URL to warm.
+	 * @return array{id: string, url: string, claimed_until: int} Queue entry.
+	 */
+	private static function new_queue_entry( string $url ): array {
+		return [
+			'id'            => wp_generate_uuid4(),
+			'url'           => $url,
+			'claimed_until' => 0,
+		];
+	}
+
+	/**
+	 * Claim the next bounded batch under the shared queue lock.
+	 *
+	 * @return array<array{id: string, url: string, claimed_until: int}> Claimed entries.
+	 */
+	private function claim_batch(): array {
+		$lock = $this->acquire_queue_lock();
+		if ( null === $lock ) {
+			return [];
+		}
+
+		try {
+			$queue         = $this->read_queue();
+			$batch         = [];
+			$now           = time();
+			$claimed_until = $now + self::WARM_CLAIM_TTL_SECONDS;
+
+			foreach ( $queue as &$entry ) {
+				if ( count( $batch ) >= self::WARM_BATCH_SIZE ) {
+					break;
+				}
+
+				if ( $entry['claimed_until'] > $now ) {
+					continue;
+				}
+
+				$entry['claimed_until'] = $claimed_until;
+				$batch[]                = $entry;
+			}
+			unset( $entry );
+
+			if ( [] !== $batch ) {
+				update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
+			}
+
+			return $batch;
+		} finally {
+			$this->release_queue_lock( $lock );
+		}
+	}
+
+	/**
+	 * Remove successful generations and rotate failures to the queue tail.
+	 *
+	 * @param array<string> $warmed Successful generation IDs.
+	 * @param array<string> $failed Failed generation IDs.
+	 */
+	private function acknowledge_batch( array $warmed, array $failed ): void {
+		$warmed_ids = array_fill_keys( $warmed, true );
+		$failed_ids = array_fill_keys( $failed, true );
+
+		$this->update_queue(
+			static function ( array $queue ) use ( $warmed_ids, $failed_ids ): array {
+				$remaining = [];
+				$retry     = [];
+
+				foreach ( $queue as $entry ) {
+					if ( isset( $warmed_ids[ $entry['id'] ] ) ) {
+						continue;
+					}
+
+					if ( isset( $failed_ids[ $entry['id'] ] ) ) {
+						$entry['claimed_until'] = 0;
+						$retry[]                = $entry;
+						continue;
+					}
+
+					$remaining[] = $entry;
+				}
+
+				return array_merge( $remaining, $retry );
+			}
+		);
 	}
 
 	/**
@@ -206,7 +335,7 @@ readonly class CachemanWarmer {
 	/**
 	 * Atomically mutate the warm queue under the shared option lock.
 	 *
-	 * @param callable(array<string>): array<string> $update Queue mutation.
+	 * @param callable(array<array{id:string,url:string,claimed_until:int}>):array<array{id:string,url:string,claimed_until:int}> $update Queue mutation.
 	 * @return bool Whether the queue was updated.
 	 */
 	private function update_queue( callable $update ): bool {
@@ -238,24 +367,24 @@ readonly class CachemanWarmer {
 		$lock = ( time() + self::WARM_QUEUE_LOCK_TTL_SECONDS ) . '|' . wp_generate_uuid4();
 
 		for ( $attempt = 0; $attempt < self::WARM_QUEUE_LOCK_ATTEMPTS; $attempt++ ) {
-			if ( add_option( self::WARM_QUEUE_LOCK, $lock, '', false ) ) {
+			if ( add_option( ZW_CACHEMAN_WARM_QUEUE_LOCK, $lock, '', false ) ) {
 				return $lock;
 			}
 
-			$current_lock = get_option( self::WARM_QUEUE_LOCK, '' );
+			$current_lock = get_option( ZW_CACHEMAN_WARM_QUEUE_LOCK, '' );
 			if ( is_string( $current_lock ) && (int) $current_lock < time() ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- A conditional update is required for atomic stale-lock recovery.
 				$updated = $wpdb->update(
 					$wpdb->options,
 					[ 'option_value' => $lock ],
 					[
-						'option_name'  => self::WARM_QUEUE_LOCK,
+						'option_name'  => ZW_CACHEMAN_WARM_QUEUE_LOCK,
 						'option_value' => $current_lock,
 					],
 					[ '%s' ],
 					[ '%s', '%s' ]
 				);
-				wp_cache_delete( self::WARM_QUEUE_LOCK, 'options' );
+				wp_cache_delete( ZW_CACHEMAN_WARM_QUEUE_LOCK, 'options' );
 
 				if ( 1 === $updated ) {
 					return $lock;
@@ -281,12 +410,12 @@ readonly class CachemanWarmer {
 		$wpdb->delete(
 			$wpdb->options,
 			[
-				'option_name'  => self::WARM_QUEUE_LOCK,
+				'option_name'  => ZW_CACHEMAN_WARM_QUEUE_LOCK,
 				'option_value' => $lock,
 			],
 			[ '%s', '%s' ]
 		);
-		wp_cache_delete( self::WARM_QUEUE_LOCK, 'options' );
+		wp_cache_delete( ZW_CACHEMAN_WARM_QUEUE_LOCK, 'options' );
 	}
 
 	/**

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -13,6 +13,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Warms page URLs after they are purged.
+ *
+ * The queue is a non-autoloaded option mutated with plain read-modify-write,
+ * like the purge queue. Warming is best-effort: concurrent writers can lose
+ * an enqueue, and overlapping cron runs can fetch a URL more than once. The
+ * worst case either way is a page warmed by a visitor instead of the server,
+ * or redundant GETs — never a missed purge.
  */
 readonly class CachemanWarmer {
 
@@ -22,8 +28,9 @@ readonly class CachemanWarmer {
 	private const WARM_TIMEOUT_SECONDS = 10;
 
 	/**
-	 * Maximum number of URLs warmed per cron run. Bounds how long a single
-	 * WP-Cron pass can block (batch x timeout stays under the cron lock).
+	 * Maximum number of URLs warmed per cron run. Bounds the warmer's share
+	 * of a WP-Cron pass to batch x timeout (nominally 50 seconds); the purge
+	 * phase that runs first has its own, unbounded duration.
 	 */
 	private const WARM_BATCH_SIZE = 5;
 
@@ -35,19 +42,6 @@ readonly class CachemanWarmer {
 	private const WARM_QUEUE_MAX = 500;
 
 	/**
-	 * Lock lifetime and retry interval. Queue mutations are local option
-	 * updates, so the lock should normally be held for only milliseconds.
-	 */
-	private const WARM_QUEUE_LOCK_TTL_SECONDS        = 30;
-	private const WARM_QUEUE_LOCK_RETRY_MICROSECONDS = 50_000;
-	private const WARM_QUEUE_LOCK_ATTEMPTS           = 40;
-
-	/**
-	 * Time before an interrupted warm claim can be retried.
-	 */
-	private const WARM_CLAIM_TTL_SECONDS = 120;
-
-	/**
 	 * Header used to authenticate cache-warming requests at Cloudflare.
 	 */
 	private const WARM_TOKEN_HEADER = 'X-ZW-Cache-Warm-Token';
@@ -55,13 +49,9 @@ readonly class CachemanWarmer {
 	/**
 	 * Constructor
 	 *
-	 * @param CachemanLogger $logger  The logger instance.
-	 * @param bool           $enabled Whether warming is enabled.
+	 * @param CachemanLogger $logger The logger instance.
 	 */
-	public function __construct(
-		private CachemanLogger $logger,
-		private bool $enabled
-	) {
+	public function __construct( private CachemanLogger $logger ) {
 	}
 
 	/**
@@ -72,13 +62,22 @@ readonly class CachemanWarmer {
 	}
 
 	/**
+	 * Whether cache warming is enabled in the plugin settings.
+	 */
+	private function is_enabled(): bool {
+		$settings = get_option( ZW_CACHEMAN_SETTINGS, [] );
+
+		return ! empty( $settings['enable_warming'] );
+	}
+
+	/**
 	 * Queue the warmable page URLs from a set of purge items. The queue is
 	 * drained in batches by the every-minute cron.
 	 *
 	 * @param array<array{type: PurgeType, url: string}> $items Purged items.
 	 */
 	public function enqueue( array $items ): void {
-		if ( ! $this->enabled ) {
+		if ( ! $this->is_enabled() ) {
 			return;
 		}
 
@@ -87,81 +86,63 @@ readonly class CachemanWarmer {
 			return;
 		}
 
-		$this->update_queue(
-			function ( array $queue ) use ( $urls ): array {
-				$pending_urls = [];
-				$now          = time();
+		$queue = array_values( array_unique( array_merge( $this->read_queue(), $urls ) ) );
 
-				foreach ( $queue as $entry ) {
-					if ( $entry['claimed_until'] <= $now ) {
-						$pending_urls[ $entry['url'] ] = true;
-					}
-				}
-
-				foreach ( $urls as $url ) {
-					if ( isset( $pending_urls[ $url ] ) ) {
-						continue;
-					}
-
-					$queue[]              = self::new_queue_entry( $url );
-					$pending_urls[ $url ] = true;
-				}
-
-				if ( count( $queue ) > self::WARM_QUEUE_MAX ) {
-					$queue = array_slice( $queue, -self::WARM_QUEUE_MAX );
-					if ( false === get_transient( ZW_CACHEMAN_WARM_QUEUE_OVERFLOW ) ) {
-						$this->logger->error( 'Warmer', 'Warm queue exceeded ' . self::WARM_QUEUE_MAX . '; dropped oldest URLs' );
-						set_transient( ZW_CACHEMAN_WARM_QUEUE_OVERFLOW, true, 5 * MINUTE_IN_SECONDS );
-					}
-				}
-
-				return $queue;
+		if ( count( $queue ) > self::WARM_QUEUE_MAX ) {
+			$queue = array_slice( $queue, -self::WARM_QUEUE_MAX );
+			// Throttle the overflow log: purge events are unbounded (think
+			// bulk imports), and error() always writes to the PHP error log.
+			if ( false === get_transient( ZW_CACHEMAN_WARM_QUEUE_OVERFLOW ) ) {
+				$this->logger->error( 'Warmer', 'Warm queue exceeded ' . self::WARM_QUEUE_MAX . '; dropped oldest URLs' );
+				set_transient( ZW_CACHEMAN_WARM_QUEUE_OVERFLOW, true, 5 * MINUTE_IN_SECONDS );
 			}
-		);
+		}
+
+		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
 	}
 
 	/**
 	 * Warm a bounded batch from the queue. Called by the manager after each
 	 * purge pass. Keeps each WP-Cron pass short instead of processing a whole
-	 * burst at once. Items are removed only after a successful warm, and the
-	 * queue is re-read before writing, so a crash mid-batch does not lose
-	 * failed URLs and the shared mutation lock preserves concurrently queued
-	 * URLs.
+	 * burst at once. URLs are removed only after their fetch completes, and
+	 * the queue is re-read before writing, which narrows — but does not
+	 * close — the window in which a concurrently enqueued URL is lost; see
+	 * the class docblock for the best-effort semantics.
 	 */
 	public function process_queue(): void {
-		if ( ! $this->enabled ) {
+		if ( ! $this->is_enabled() ) {
 			// Warming was turned off; drop any URLs still parked in the queue.
-			if ( [] !== $this->read_queue() ) {
-				$this->clear_queue();
-			}
+			delete_option( ZW_CACHEMAN_WARM_QUEUE );
 			return;
 		}
 
-		$batch = $this->claim_batch();
+		$batch = array_slice( $this->read_queue(), 0, self::WARM_BATCH_SIZE );
 		if ( empty( $batch ) ) {
 			return;
 		}
 
-		$warmed = [];
 		$failed = [];
-		foreach ( $batch as $entry ) {
-			if ( $this->warm( $entry['url'] ) ) {
-				$warmed[] = $entry['id'];
-			} else {
-				$failed[] = $entry['id'];
+		foreach ( $batch as $url ) {
+			if ( ! $this->warm( $url ) ) {
+				$failed[] = $url;
 			}
 		}
 
-		$this->acknowledge_batch( $warmed, $failed );
+		// Drop the fetched batch, keep URLs enqueued while it was in flight,
+		// and rotate transport failures to the tail for a later retry.
+		$queue = array_merge( array_diff( $this->read_queue(), $batch ), $failed );
+		update_option( ZW_CACHEMAN_WARM_QUEUE, array_values( $queue ), false );
 	}
 
 	/**
-	 * Warm a single URL by fetching it.
+	 * Warm a single URL by fetching it through the WordPress HTTP API, so
+	 * proxy configuration, external-request blocking, and the HTTP API
+	 * filters keep applying to warm requests.
 	 *
 	 * Returns false only on a transport error (WP_Error), so the URL stays
-	 * queued for a retry. Any HTTP response — including 4xx/5xx — is treated as
-	 * terminal (the URL is dequeued) to avoid retrying a permanently missing
-	 * page forever.
+	 * queued for a retry. Any HTTP response — including 4xx/5xx — is treated
+	 * as terminal (the URL is dequeued) to avoid retrying a permanently
+	 * missing page forever.
 	 *
 	 * @param string $url URL to warm.
 	 * @return bool Whether the URL can be dequeued.
@@ -193,12 +174,9 @@ readonly class CachemanWarmer {
 	}
 
 	/**
-	 * Read and normalize the warm queue.
+	 * Read the warm queue, dropping anything that is not a non-empty string.
 	 *
-	 * Legacy string entries are upgraded in memory and persisted by the next
-	 * queue mutation.
-	 *
-	 * @return array<array{id: string, url: string, claimed_until: int}> Queue entries.
+	 * @return array<string> Queued URLs.
 	 */
 	private function read_queue(): array {
 		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
@@ -206,216 +184,9 @@ readonly class CachemanWarmer {
 			return [];
 		}
 
-		$normalized = [];
-		foreach ( $queue as $entry ) {
-			if ( is_string( $entry ) && '' !== $entry ) {
-				$normalized[] = self::new_queue_entry( $entry );
-				continue;
-			}
-
-			if ( ! is_array( $entry ) || ! isset( $entry['url'] ) || ! is_string( $entry['url'] ) || '' === $entry['url'] ) {
-				continue;
-			}
-
-			$normalized[] = [
-				'id'            => isset( $entry['id'] ) && is_string( $entry['id'] ) && '' !== $entry['id'] ? $entry['id'] : wp_generate_uuid4(),
-				'url'           => $entry['url'],
-				'claimed_until' => isset( $entry['claimed_until'] ) ? (int) $entry['claimed_until'] : 0,
-			];
-		}
-
-		return $normalized;
-	}
-
-	/**
-	 * Create a new pending queue generation.
-	 *
-	 * @param string $url URL to warm.
-	 * @return array{id: string, url: string, claimed_until: int} Queue entry.
-	 */
-	private static function new_queue_entry( string $url ): array {
-		return [
-			'id'            => wp_generate_uuid4(),
-			'url'           => $url,
-			'claimed_until' => 0,
-		];
-	}
-
-	/**
-	 * Claim the next bounded batch under the shared queue lock.
-	 *
-	 * @return array<array{id: string, url: string, claimed_until: int}> Claimed entries.
-	 */
-	private function claim_batch(): array {
-		$lock = $this->acquire_queue_lock();
-		if ( null === $lock ) {
-			return [];
-		}
-
-		try {
-			$queue         = $this->read_queue();
-			$batch         = [];
-			$now           = time();
-			$claimed_until = $now + self::WARM_CLAIM_TTL_SECONDS;
-
-			foreach ( $queue as &$entry ) {
-				if ( count( $batch ) >= self::WARM_BATCH_SIZE ) {
-					break;
-				}
-
-				if ( $entry['claimed_until'] > $now ) {
-					continue;
-				}
-
-				$entry['claimed_until'] = $claimed_until;
-				$batch[]                = $entry;
-			}
-			unset( $entry );
-
-			if ( [] !== $batch ) {
-				update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
-			}
-
-			return $batch;
-		} finally {
-			$this->release_queue_lock( $lock );
-		}
-	}
-
-	/**
-	 * Remove successful generations and rotate failures to the queue tail.
-	 *
-	 * @param array<string> $warmed Successful generation IDs.
-	 * @param array<string> $failed Failed generation IDs.
-	 */
-	private function acknowledge_batch( array $warmed, array $failed ): void {
-		$warmed_ids = array_fill_keys( $warmed, true );
-		$failed_ids = array_fill_keys( $failed, true );
-
-		$this->update_queue(
-			static function ( array $queue ) use ( $warmed_ids, $failed_ids ): array {
-				$remaining = [];
-				$retry     = [];
-
-				foreach ( $queue as $entry ) {
-					if ( isset( $warmed_ids[ $entry['id'] ] ) ) {
-						continue;
-					}
-
-					if ( isset( $failed_ids[ $entry['id'] ] ) ) {
-						$entry['claimed_until'] = 0;
-						$retry[]                = $entry;
-						continue;
-					}
-
-					$remaining[] = $entry;
-				}
-
-				return array_merge( $remaining, $retry );
-			}
+		return array_values(
+			array_filter( $queue, static fn ( $url ): bool => is_string( $url ) && '' !== $url )
 		);
-	}
-
-	/**
-	 * Delete the warm queue under the shared option lock.
-	 */
-	private function clear_queue(): void {
-		$lock = $this->acquire_queue_lock();
-		if ( null === $lock ) {
-			return;
-		}
-
-		try {
-			delete_option( ZW_CACHEMAN_WARM_QUEUE );
-		} finally {
-			$this->release_queue_lock( $lock );
-		}
-	}
-
-	/**
-	 * Atomically mutate the warm queue under the shared option lock.
-	 *
-	 * @param callable(array<array{id:string,url:string,claimed_until:int}>):array<array{id:string,url:string,claimed_until:int}> $update Queue mutation.
-	 * @return bool Whether the queue was updated.
-	 */
-	private function update_queue( callable $update ): bool {
-		$lock = $this->acquire_queue_lock();
-		if ( null === $lock ) {
-			return false;
-		}
-
-		try {
-			update_option( ZW_CACHEMAN_WARM_QUEUE, $update( $this->read_queue() ), false );
-			return true;
-		} finally {
-			$this->release_queue_lock( $lock );
-		}
-	}
-
-	/**
-	 * Acquire the shared warm-queue lock.
-	 *
-	 * The add_option() function provides the atomic uncontended path. An
-	 * expired lock is replaced with a compare-and-swap update so only one
-	 * waiter can steal it.
-	 *
-	 * @return string|null Lock value owned by this request, or null on timeout.
-	 */
-	private function acquire_queue_lock(): ?string {
-		global $wpdb;
-
-		$lock = ( time() + self::WARM_QUEUE_LOCK_TTL_SECONDS ) . '|' . wp_generate_uuid4();
-
-		for ( $attempt = 0; $attempt < self::WARM_QUEUE_LOCK_ATTEMPTS; $attempt++ ) {
-			if ( add_option( ZW_CACHEMAN_WARM_QUEUE_LOCK, $lock, '', false ) ) {
-				return $lock;
-			}
-
-			$current_lock = get_option( ZW_CACHEMAN_WARM_QUEUE_LOCK, '' );
-			if ( is_string( $current_lock ) && (int) $current_lock < time() ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- A conditional update is required for atomic stale-lock recovery.
-				$updated = $wpdb->update(
-					$wpdb->options,
-					[ 'option_value' => $lock ],
-					[
-						'option_name'  => ZW_CACHEMAN_WARM_QUEUE_LOCK,
-						'option_value' => $current_lock,
-					],
-					[ '%s' ],
-					[ '%s', '%s' ]
-				);
-				wp_cache_delete( ZW_CACHEMAN_WARM_QUEUE_LOCK, 'options' );
-
-				if ( 1 === $updated ) {
-					return $lock;
-				}
-			}
-
-			usleep( self::WARM_QUEUE_LOCK_RETRY_MICROSECONDS );
-		}
-
-		$this->logger->error( 'Warmer', 'Could not acquire the warm queue lock; queue update skipped' );
-		return null;
-	}
-
-	/**
-	 * Release the lock only when it is still owned by this request.
-	 *
-	 * @param string $lock Lock value returned by acquire_queue_lock().
-	 */
-	private function release_queue_lock( string $lock ): void {
-		global $wpdb;
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- The owner check prevents an expired lock from releasing its replacement.
-		$wpdb->delete(
-			$wpdb->options,
-			[
-				'option_name'  => ZW_CACHEMAN_WARM_QUEUE_LOCK,
-				'option_value' => $lock,
-			],
-			[ '%s', '%s' ]
-		);
-		wp_cache_delete( ZW_CACHEMAN_WARM_QUEUE_LOCK, 'options' );
 	}
 
 	/**

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -35,6 +35,18 @@ readonly class CachemanWarmer {
 	private const WARM_QUEUE_MAX = 500;
 
 	/**
+	 * Header used to authenticate cache-warming requests at Cloudflare.
+	 */
+	private const WARM_TOKEN_HEADER = 'X-ZW-Cache-Warm-Token';
+
+	/**
+	 * Validated WAF token, or null when it is missing or invalid.
+	 *
+	 * @var string|null
+	 */
+	private ?string $waf_token;
+
+	/**
 	 * Constructor
 	 *
 	 * @param CachemanLogger $logger  The logger instance.
@@ -44,15 +56,26 @@ readonly class CachemanWarmer {
 		private CachemanLogger $logger,
 		private bool $enabled = false
 	) {
-		add_action( ZW_CACHEMAN_WARM_HOOK, $this->process_queue( ... ) );
+		$this->waf_token = self::configured_waf_token();
+
+		// Purge first (priority 10), then drain the warm queue.
+		add_action( ZW_CACHEMAN_CRON_HOOK, $this->process_queue( ... ), 20 );
 	}
 
 	/**
-	 * Queue the warmable page URLs from a set of purge items.
+	 * Whether a valid WAF token is configured in wp-config.php.
+	 */
+	public static function has_valid_waf_token(): bool {
+		return null !== self::configured_waf_token();
+	}
+
+	/**
+	 * Queue the warmable page URLs from a set of purge items. The queue is
+	 * drained in batches by the every-minute cron.
 	 *
 	 * @param array<array{type: PurgeType, url: string}> $items Purged items.
 	 */
-	public function schedule( array $items ): void {
+	public function enqueue( array $items ): void {
 		if ( ! $this->enabled ) {
 			return;
 		}
@@ -74,16 +97,13 @@ readonly class CachemanWarmer {
 		}
 
 		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
-
-		$this->schedule_run();
 	}
 
 	/**
-	 * Warm a bounded batch from the queue, rescheduling while items remain
-	 * (cron callback). Keeps each WP-Cron pass short instead of processing a
-	 * whole burst at once. Items are removed only after a successful warm, and
-	 * the queue is re-read before writing, so a crash mid-batch and URLs queued
-	 * concurrently are not lost.
+	 * Warm a bounded batch from the queue (cron callback). Keeps each WP-Cron
+	 * pass short instead of processing a whole burst at once. Items are removed
+	 * only after a successful warm, and the queue is re-read before writing, so
+	 * a crash mid-batch and URLs queued concurrently are not lost.
 	 */
 	public function process_queue(): void {
 		if ( ! $this->enabled ) {
@@ -104,31 +124,8 @@ readonly class CachemanWarmer {
 
 		// Re-read and drop only the URLs we warmed; anything enqueued in the
 		// meantime and any failed fetches stay queued for the next run.
-		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
-		if ( ! is_array( $queue ) ) {
-			$queue = [];
-		}
-		$queue = array_values( array_diff( $queue, $warmed ) );
+		$queue = array_values( array_diff( (array) get_option( ZW_CACHEMAN_WARM_QUEUE, [] ), $warmed ) );
 		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
-
-		if ( ! empty( $queue ) ) {
-			$this->schedule_run();
-		}
-	}
-
-	/**
-	 * Ensure a single drain event is scheduled.
-	 */
-	private function schedule_run(): void {
-		if ( wp_next_scheduled( ZW_CACHEMAN_WARM_HOOK ) ) {
-			return;
-		}
-
-		if ( wp_schedule_single_event( time(), ZW_CACHEMAN_WARM_HOOK ) ) {
-			$this->logger->debug( 'Warmer', 'Scheduled warm run' );
-		} else {
-			$this->logger->error( 'Warmer', 'Failed to schedule warm run' );
-		}
 	}
 
 	/**
@@ -143,18 +140,18 @@ readonly class CachemanWarmer {
 	 * @return bool Whether the URL can be dequeued.
 	 */
 	private function warm( string $url ): bool {
-		if ( '' === $url ) {
-			return true;
+		$headers = [ 'X-ZW-Cache-Warm' => '1' ];
+		if ( null !== $this->waf_token ) {
+			$headers[ self::WARM_TOKEN_HEADER ] = $this->waf_token;
 		}
 
 		$response = wp_remote_get(
 			$url,
 			[
-				'blocking'    => true,
 				'timeout'     => self::WARM_TIMEOUT_SECONDS,
 				'redirection' => 0,
 				'user-agent'  => 'ZWCacheMan-Warmer',
-				'headers'     => [ 'X-ZW-Cache-Warm' => '1' ],
+				'headers'     => $headers,
 			]
 		);
 
@@ -168,10 +165,31 @@ readonly class CachemanWarmer {
 	}
 
 	/**
+	 * Read and validate the cache-warming token from wp-config.php.
+	 *
+	 * Tokens are deliberately not stored in the WordPress database. A
+	 * 32-byte random value encoded as 64 hexadecimal characters is required.
+	 *
+	 * @return string|null Valid token, or null when missing or invalid.
+	 */
+	private static function configured_waf_token(): ?string {
+		if ( ! defined( 'ZW_CACHEMAN_WARM_TOKEN' ) ) {
+			return null;
+		}
+
+		$token = constant( 'ZW_CACHEMAN_WARM_TOKEN' );
+		if ( ! is_string( $token ) || 1 !== preg_match( '/\A[0-9a-f]{64}\z/i', $token ) ) {
+			return null;
+		}
+
+		return $token;
+	}
+
+	/**
 	 * Reduce purge items to warmable front-end page URLs.
 	 *
 	 * @param array<array{type: PurgeType, url: string}> $items Purge items.
-	 * @return array<string> Unique page URLs.
+	 * @return array<string> Page URLs.
 	 */
 	private function page_urls_from_items( array $items ): array {
 		// Match the REST base by path (from rest_url(), so it includes any
@@ -193,9 +211,9 @@ readonly class CachemanWarmer {
 				continue;
 			}
 
-			$urls[ $url ] = $url;
+			$urls[] = $url;
 		}
 
-		return array_values( $urls );
+		return $urls;
 	}
 }

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -78,7 +78,10 @@ readonly class CachemanWarmer {
 
 		if ( count( $queue ) > self::WARM_QUEUE_MAX ) {
 			$queue = array_slice( $queue, -self::WARM_QUEUE_MAX );
-			$this->logger->error( 'Warmer', 'Warm queue exceeded ' . self::WARM_QUEUE_MAX . '; dropped oldest URLs' );
+			if ( false === get_transient( 'zw_cacheman_warm_queue_overflow' ) ) {
+				$this->logger->error( 'Warmer', 'Warm queue exceeded ' . self::WARM_QUEUE_MAX . '; dropped oldest URLs' );
+				set_transient( 'zw_cacheman_warm_queue_overflow', true, 5 * MINUTE_IN_SECONDS );
+			}
 		}
 
 		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -40,13 +40,6 @@ readonly class CachemanWarmer {
 	private const WARM_TOKEN_HEADER = 'X-ZW-Cache-Warm-Token';
 
 	/**
-	 * Validated WAF token, or null when it is missing or invalid.
-	 *
-	 * @var string|null
-	 */
-	private ?string $waf_token;
-
-	/**
 	 * Constructor
 	 *
 	 * @param CachemanLogger $logger  The logger instance.
@@ -54,12 +47,8 @@ readonly class CachemanWarmer {
 	 */
 	public function __construct(
 		private CachemanLogger $logger,
-		private bool $enabled = false
+		private bool $enabled
 	) {
-		$this->waf_token = self::configured_waf_token();
-
-		// Purge first (priority 10), then drain the warm queue.
-		add_action( ZW_CACHEMAN_CRON_HOOK, $this->process_queue( ... ), 20 );
 	}
 
 	/**
@@ -85,11 +74,7 @@ readonly class CachemanWarmer {
 			return;
 		}
 
-		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
-		if ( ! is_array( $queue ) ) {
-			$queue = [];
-		}
-		$queue = array_values( array_unique( array_merge( $queue, $urls ) ) );
+		$queue = array_values( array_unique( array_merge( $this->read_queue(), $urls ) ) );
 
 		if ( count( $queue ) > self::WARM_QUEUE_MAX ) {
 			$queue = array_slice( $queue, -self::WARM_QUEUE_MAX );
@@ -100,18 +85,24 @@ readonly class CachemanWarmer {
 	}
 
 	/**
-	 * Warm a bounded batch from the queue (cron callback). Keeps each WP-Cron
-	 * pass short instead of processing a whole burst at once. Items are removed
-	 * only after a successful warm, and the queue is re-read before writing, so
-	 * a crash mid-batch and URLs queued concurrently are not lost.
+	 * Warm a bounded batch from the queue. Called by the manager after each
+	 * purge pass. Keeps each WP-Cron pass short instead of processing a whole
+	 * burst at once. Items are removed only after a successful warm, and the
+	 * queue is re-read before writing, so a crash mid-batch does not lose
+	 * failed URLs and (with a persistent object cache) concurrently queued
+	 * URLs are preserved.
 	 */
 	public function process_queue(): void {
 		if ( ! $this->enabled ) {
+			// Warming was turned off; drop any URLs still parked in the queue.
+			if ( [] !== $this->read_queue() ) {
+				delete_option( ZW_CACHEMAN_WARM_QUEUE );
+			}
 			return;
 		}
 
-		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
-		if ( ! is_array( $queue ) || empty( $queue ) ) {
+		$queue = $this->read_queue();
+		if ( empty( $queue ) ) {
 			return;
 		}
 
@@ -122,9 +113,9 @@ readonly class CachemanWarmer {
 			}
 		}
 
-		// Re-read and drop only the URLs we warmed; anything enqueued in the
-		// meantime and any failed fetches stay queued for the next run.
-		$queue = array_values( array_diff( (array) get_option( ZW_CACHEMAN_WARM_QUEUE, [] ), $warmed ) );
+		// Re-read and drop only the URLs we warmed; failed fetches stay
+		// queued for the next run.
+		$queue = array_values( array_diff( $this->read_queue(), $warmed ) );
 		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
 	}
 
@@ -140,9 +131,10 @@ readonly class CachemanWarmer {
 	 * @return bool Whether the URL can be dequeued.
 	 */
 	private function warm( string $url ): bool {
-		$headers = [ 'X-ZW-Cache-Warm' => '1' ];
-		if ( null !== $this->waf_token ) {
-			$headers[ self::WARM_TOKEN_HEADER ] = $this->waf_token;
+		$headers = [];
+		$token   = self::configured_waf_token();
+		if ( null !== $token ) {
+			$headers[ self::WARM_TOKEN_HEADER ] = $token;
 		}
 
 		$response = wp_remote_get(
@@ -162,6 +154,16 @@ readonly class CachemanWarmer {
 
 		$this->logger->debug( 'Warmer', 'Warmed ' . $url . ' (HTTP ' . wp_remote_retrieve_response_code( $response ) . ')' );
 		return true;
+	}
+
+	/**
+	 * Read the warm queue option, normalizing a corrupt value to an empty list.
+	 *
+	 * @return array<string> Queued URLs.
+	 */
+	private function read_queue(): array {
+		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
+		return is_array( $queue ) ? $queue : [];
 	}
 
 	/**

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Cache warming functionality for ZuidWest Cache Manager.
+ *
+ * @package ZuidWestCacheMan
+ */
+
+namespace ZW_CACHEMAN_Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Warms page URLs after they are purged.
+ */
+readonly class CachemanWarmer {
+
+	/**
+	 * Request timeout, in seconds, for a single warm fetch.
+	 */
+	private const WARM_TIMEOUT_SECONDS = 15;
+
+	/**
+	 * Constructor
+	 *
+	 * @param CachemanLogger $logger  The logger instance.
+	 * @param bool           $enabled Whether warming is enabled.
+	 */
+	public function __construct(
+		private CachemanLogger $logger,
+		private bool $enabled = false
+	) {
+		add_action( ZW_CACHEMAN_WARM_HOOK, $this->warm( ... ), 10, 1 );
+	}
+
+	/**
+	 * Schedule warming for the page URLs among a set of purge items.
+	 *
+	 * @param array<array{type: PurgeType, url: string}> $items Purged items.
+	 */
+	public function schedule( array $items ): void {
+		if ( ! $this->enabled ) {
+			return;
+		}
+
+		// One event per URL, so repeats (e.g. the homepage after a burst of
+		// publishes) de-duplicate within WP-Cron's 10-minute window.
+		foreach ( $this->page_urls_from_items( $items ) as $url ) {
+			if ( ! wp_next_scheduled( ZW_CACHEMAN_WARM_HOOK, [ $url ] ) ) {
+				wp_schedule_single_event( time(), ZW_CACHEMAN_WARM_HOOK, [ $url ] );
+				$this->logger->debug( 'Warmer', 'Scheduled warming of ' . $url );
+			}
+		}
+	}
+
+	/**
+	 * Warm a single URL by fetching it (cron callback).
+	 *
+	 * @param string $url URL to warm.
+	 */
+	public function warm( string $url ): void {
+		if ( ! $this->enabled || '' === $url ) {
+			return;
+		}
+
+		$response = wp_remote_get(
+			$url,
+			[
+				'blocking'    => true,
+				'timeout'     => self::WARM_TIMEOUT_SECONDS,
+				'redirection' => 0,
+				'user-agent'  => 'ZWCacheMan-Warmer',
+				'headers'     => [ 'X-ZW-Cache-Warm' => '1' ],
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$this->logger->error( 'Warmer', 'Failed to warm ' . $url . ': ' . $response->get_error_message() );
+		} else {
+			$this->logger->debug( 'Warmer', 'Warmed ' . $url . ' (HTTP ' . wp_remote_retrieve_response_code( $response ) . ')' );
+		}
+	}
+
+	/**
+	 * Reduce purge items to warmable front-end page URLs.
+	 *
+	 * @param array<array{type: PurgeType, url: string}> $items Purge items.
+	 * @return array<string> Unique page URLs.
+	 */
+	private function page_urls_from_items( array $items ): array {
+		// Match the REST base by path, so REST URLs on extra domains (different
+		// host, same "/wp-json/" path) are excluded too.
+		$rest_path = '/' . trim( rest_get_url_prefix(), '/' ) . '/';
+		$urls      = [];
+
+		foreach ( $items as $item ) {
+			if ( PurgeType::File !== $item['type'] ) {
+				continue;
+			}
+
+			$url  = $item['url'];
+			$path = (string) wp_parse_url( $url, PHP_URL_PATH );
+
+			if ( str_starts_with( $path, $rest_path ) ) {
+				continue;
+			}
+
+			$urls[ $url ] = $url;
+		}
+
+		return array_values( $urls );
+	}
+}

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -19,13 +19,13 @@ readonly class CachemanWarmer {
 	/**
 	 * Request timeout, in seconds, for a single warm fetch.
 	 */
-	private const WARM_TIMEOUT_SECONDS = 15;
+	private const WARM_TIMEOUT_SECONDS = 10;
 
 	/**
-	 * Spacing, in seconds, between warm events so a burst does not run
-	 * back-to-back in a single WP-Cron pass.
+	 * Maximum number of URLs warmed per cron run. Bounds how long a single
+	 * WP-Cron pass can block (batch x timeout stays under the cron lock).
 	 */
-	private const WARM_STAGGER_SECONDS = 15;
+	private const WARM_BATCH_SIZE = 5;
 
 	/**
 	 * Constructor
@@ -37,11 +37,11 @@ readonly class CachemanWarmer {
 		private CachemanLogger $logger,
 		private bool $enabled = false
 	) {
-		add_action( ZW_CACHEMAN_WARM_HOOK, $this->warm( ... ), 10, 1 );
+		add_action( ZW_CACHEMAN_WARM_HOOK, $this->process_queue( ... ) );
 	}
 
 	/**
-	 * Schedule warming for the page URLs among a set of purge items.
+	 * Queue the warmable page URLs from a set of purge items.
 	 *
 	 * @param array<array{type: PurgeType, url: string}> $items Purged items.
 	 */
@@ -50,28 +50,71 @@ readonly class CachemanWarmer {
 			return;
 		}
 
-		// One event per URL, so repeats (e.g. the homepage after a burst of
-		// publishes) de-duplicate within WP-Cron's window. Events are staggered
-		// so a large batch does not run back-to-back in a single cron pass and
-		// tie up the worker.
-		$offset = 0;
-		foreach ( $this->page_urls_from_items( $items ) as $url ) {
-			if ( wp_next_scheduled( ZW_CACHEMAN_WARM_HOOK, [ $url ] ) ) {
-				continue;
-			}
-			wp_schedule_single_event( time() + $offset, ZW_CACHEMAN_WARM_HOOK, [ $url ] );
-			$this->logger->debug( 'Warmer', 'Scheduled warming of ' . $url );
-			$offset += self::WARM_STAGGER_SECONDS;
+		$urls = $this->page_urls_from_items( $items );
+		if ( empty( $urls ) ) {
+			return;
+		}
+
+		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
+		if ( ! is_array( $queue ) ) {
+			$queue = [];
+		}
+		$queue = array_values( array_unique( array_merge( $queue, $urls ) ) );
+		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
+
+		$this->schedule_run();
+	}
+
+	/**
+	 * Warm a bounded batch from the queue, rescheduling while items remain
+	 * (cron callback). Keeps each WP-Cron pass short instead of processing a
+	 * whole burst at once.
+	 */
+	public function process_queue(): void {
+		if ( ! $this->enabled ) {
+			return;
+		}
+
+		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
+		if ( ! is_array( $queue ) || empty( $queue ) ) {
+			return;
+		}
+
+		$batch     = array_slice( $queue, 0, self::WARM_BATCH_SIZE );
+		$remaining = array_slice( $queue, self::WARM_BATCH_SIZE );
+		update_option( ZW_CACHEMAN_WARM_QUEUE, $remaining, false );
+
+		foreach ( $batch as $url ) {
+			$this->warm( $url );
+		}
+
+		if ( ! empty( $remaining ) ) {
+			$this->schedule_run();
 		}
 	}
 
 	/**
-	 * Warm a single URL by fetching it (cron callback).
+	 * Ensure a single drain event is scheduled.
+	 */
+	private function schedule_run(): void {
+		if ( wp_next_scheduled( ZW_CACHEMAN_WARM_HOOK ) ) {
+			return;
+		}
+
+		if ( wp_schedule_single_event( time(), ZW_CACHEMAN_WARM_HOOK ) ) {
+			$this->logger->debug( 'Warmer', 'Scheduled warm run' );
+		} else {
+			$this->logger->error( 'Warmer', 'Failed to schedule warm run' );
+		}
+	}
+
+	/**
+	 * Warm a single URL by fetching it.
 	 *
 	 * @param string $url URL to warm.
 	 */
-	public function warm( string $url ): void {
-		if ( ! $this->enabled || '' === $url ) {
+	private function warm( string $url ): void {
+		if ( '' === $url ) {
 			return;
 		}
 

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -22,6 +22,12 @@ readonly class CachemanWarmer {
 	private const WARM_TIMEOUT_SECONDS = 15;
 
 	/**
+	 * Spacing, in seconds, between warm events so a burst does not run
+	 * back-to-back in a single WP-Cron pass.
+	 */
+	private const WARM_STAGGER_SECONDS = 15;
+
+	/**
 	 * Constructor
 	 *
 	 * @param CachemanLogger $logger  The logger instance.
@@ -45,12 +51,17 @@ readonly class CachemanWarmer {
 		}
 
 		// One event per URL, so repeats (e.g. the homepage after a burst of
-		// publishes) de-duplicate within WP-Cron's 10-minute window.
+		// publishes) de-duplicate within WP-Cron's window. Events are staggered
+		// so a large batch does not run back-to-back in a single cron pass and
+		// tie up the worker.
+		$offset = 0;
 		foreach ( $this->page_urls_from_items( $items ) as $url ) {
-			if ( ! wp_next_scheduled( ZW_CACHEMAN_WARM_HOOK, [ $url ] ) ) {
-				wp_schedule_single_event( time(), ZW_CACHEMAN_WARM_HOOK, [ $url ] );
-				$this->logger->debug( 'Warmer', 'Scheduled warming of ' . $url );
+			if ( wp_next_scheduled( ZW_CACHEMAN_WARM_HOOK, [ $url ] ) ) {
+				continue;
 			}
+			wp_schedule_single_event( time() + $offset, ZW_CACHEMAN_WARM_HOOK, [ $url ] );
+			$this->logger->debug( 'Warmer', 'Scheduled warming of ' . $url );
+			$offset += self::WARM_STAGGER_SECONDS;
 		}
 	}
 
@@ -89,9 +100,11 @@ readonly class CachemanWarmer {
 	 * @return array<string> Unique page URLs.
 	 */
 	private function page_urls_from_items( array $items ): array {
-		// Match the REST base by path, so REST URLs on extra domains (different
-		// host, same "/wp-json/" path) are excluded too.
-		$rest_path = '/' . trim( rest_get_url_prefix(), '/' ) . '/';
+		// Match the REST base by path (from rest_url(), so it includes any
+		// subdirectory install path) and compare host-agnostically, so REST
+		// URLs on extra domains are excluded too. Guard the plain-permalink
+		// case where the REST path is just "/".
+		$rest_path = (string) wp_parse_url( rest_url(), PHP_URL_PATH );
 		$urls      = [];
 
 		foreach ( $items as $item ) {
@@ -102,7 +115,7 @@ readonly class CachemanWarmer {
 			$url  = $item['url'];
 			$path = (string) wp_parse_url( $url, PHP_URL_PATH );
 
-			if ( str_starts_with( $path, $rest_path ) ) {
+			if ( '/' !== $rest_path && str_starts_with( $path, $rest_path ) ) {
 				continue;
 			}
 

--- a/includes/warmer.php
+++ b/includes/warmer.php
@@ -28,6 +28,13 @@ readonly class CachemanWarmer {
 	private const WARM_BATCH_SIZE = 5;
 
 	/**
+	 * Maximum number of URLs held in the queue. Backpressure so the option
+	 * cannot grow without bound if warming falls behind; the oldest entries
+	 * are dropped once the cap is reached.
+	 */
+	private const WARM_QUEUE_MAX = 500;
+
+	/**
 	 * Constructor
 	 *
 	 * @param CachemanLogger $logger  The logger instance.
@@ -60,6 +67,12 @@ readonly class CachemanWarmer {
 			$queue = [];
 		}
 		$queue = array_values( array_unique( array_merge( $queue, $urls ) ) );
+
+		if ( count( $queue ) > self::WARM_QUEUE_MAX ) {
+			$queue = array_slice( $queue, -self::WARM_QUEUE_MAX );
+			$this->logger->error( 'Warmer', 'Warm queue exceeded ' . self::WARM_QUEUE_MAX . '; dropped oldest URLs' );
+		}
+
 		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
 
 		$this->schedule_run();
@@ -68,7 +81,9 @@ readonly class CachemanWarmer {
 	/**
 	 * Warm a bounded batch from the queue, rescheduling while items remain
 	 * (cron callback). Keeps each WP-Cron pass short instead of processing a
-	 * whole burst at once.
+	 * whole burst at once. Items are removed only after a successful warm, and
+	 * the queue is re-read before writing, so a crash mid-batch and URLs queued
+	 * concurrently are not lost.
 	 */
 	public function process_queue(): void {
 		if ( ! $this->enabled ) {
@@ -80,15 +95,23 @@ readonly class CachemanWarmer {
 			return;
 		}
 
-		$batch     = array_slice( $queue, 0, self::WARM_BATCH_SIZE );
-		$remaining = array_slice( $queue, self::WARM_BATCH_SIZE );
-		update_option( ZW_CACHEMAN_WARM_QUEUE, $remaining, false );
-
-		foreach ( $batch as $url ) {
-			$this->warm( $url );
+		$warmed = [];
+		foreach ( array_slice( $queue, 0, self::WARM_BATCH_SIZE ) as $url ) {
+			if ( $this->warm( $url ) ) {
+				$warmed[] = $url;
+			}
 		}
 
-		if ( ! empty( $remaining ) ) {
+		// Re-read and drop only the URLs we warmed; anything enqueued in the
+		// meantime and any failed fetches stay queued for the next run.
+		$queue = get_option( ZW_CACHEMAN_WARM_QUEUE, [] );
+		if ( ! is_array( $queue ) ) {
+			$queue = [];
+		}
+		$queue = array_values( array_diff( $queue, $warmed ) );
+		update_option( ZW_CACHEMAN_WARM_QUEUE, $queue, false );
+
+		if ( ! empty( $queue ) ) {
 			$this->schedule_run();
 		}
 	}
@@ -111,11 +134,17 @@ readonly class CachemanWarmer {
 	/**
 	 * Warm a single URL by fetching it.
 	 *
+	 * Returns false only on a transport error (WP_Error), so the URL stays
+	 * queued for a retry. Any HTTP response — including 4xx/5xx — is treated as
+	 * terminal (the URL is dequeued) to avoid retrying a permanently missing
+	 * page forever.
+	 *
 	 * @param string $url URL to warm.
+	 * @return bool Whether the URL can be dequeued.
 	 */
-	private function warm( string $url ): void {
+	private function warm( string $url ): bool {
 		if ( '' === $url ) {
-			return;
+			return true;
 		}
 
 		$response = wp_remote_get(
@@ -131,9 +160,11 @@ readonly class CachemanWarmer {
 
 		if ( is_wp_error( $response ) ) {
 			$this->logger->error( 'Warmer', 'Failed to warm ' . $url . ': ' . $response->get_error_message() );
-		} else {
-			$this->logger->debug( 'Warmer', 'Warmed ' . $url . ' (HTTP ' . wp_remote_retrieve_response_code( $response ) . ')' );
+			return false;
 		}
+
+		$this->logger->debug( 'Warmer', 'Warmed ' . $url . ' (HTTP ' . wp_remote_retrieve_response_code( $response ) . ')' );
+		return true;
 	}
 
 	/**

--- a/zw-cacheman.php
+++ b/zw-cacheman.php
@@ -24,6 +24,7 @@ define( 'ZW_CACHEMAN_URL', plugin_dir_url( __FILE__ ) );
 define( 'ZW_CACHEMAN_QUEUE', 'zw_cacheman_queue' );
 define( 'ZW_CACHEMAN_SETTINGS', 'zw_cacheman_settings' );
 define( 'ZW_CACHEMAN_CRON_HOOK', 'zw_cacheman_cron_hook' );
+define( 'ZW_CACHEMAN_WARM_HOOK', 'zw_cacheman_warm_hook' );
 
 // Includes required files.
 require_once ZW_CACHEMAN_DIR . 'includes/enum-purge-type.php';
@@ -34,6 +35,7 @@ require_once ZW_CACHEMAN_DIR . 'includes/sitemap-provider.php';
 require_once ZW_CACHEMAN_DIR . 'includes/sitemap-provider-yoast.php';
 require_once ZW_CACHEMAN_DIR . 'includes/sitemap-provider-factory.php';
 require_once ZW_CACHEMAN_DIR . 'includes/url-delver.php';
+require_once ZW_CACHEMAN_DIR . 'includes/warmer.php';
 require_once ZW_CACHEMAN_DIR . 'includes/cache-manager.php';
 require_once ZW_CACHEMAN_DIR . 'includes/admin.php';
 
@@ -53,7 +55,8 @@ function zw_cacheman_init() {
 
 	$sitemap_provider = ZW_CACHEMAN_Core\CachemanSitemapProviderFactory::detect( $logger );
 	$url_delver       = new ZW_CACHEMAN_Core\CachemanUrlDelver( $url_helper, $logger, $sitemap_provider );
-	$manager          = new ZW_CACHEMAN_Core\CachemanManager( $api, $url_delver, $logger );
+	$warmer           = new ZW_CACHEMAN_Core\CachemanWarmer( $logger, ! empty( $settings['enable_warming'] ) );
+	$manager          = new ZW_CACHEMAN_Core\CachemanManager( $api, $url_delver, $logger, $warmer );
 
 	// Only load admin interface in admin area.
 	if ( is_admin() ) {
@@ -98,6 +101,10 @@ function zw_cacheman_deactivate() {
 	if ( $timestamp ) {
 		wp_unschedule_event( $timestamp, ZW_CACHEMAN_CRON_HOOK );
 	}
+
+	// Clear pending one-off warming events. wp_unschedule_hook() clears them
+	// regardless of their per-URL args (wp_clear_scheduled_hook() would not).
+	wp_unschedule_hook( ZW_CACHEMAN_WARM_HOOK );
 }
 register_deactivation_hook( __FILE__, 'zw_cacheman_deactivate' );
 

--- a/zw-cacheman.php
+++ b/zw-cacheman.php
@@ -24,7 +24,6 @@ define( 'ZW_CACHEMAN_URL', plugin_dir_url( __FILE__ ) );
 define( 'ZW_CACHEMAN_QUEUE', 'zw_cacheman_queue' );
 define( 'ZW_CACHEMAN_SETTINGS', 'zw_cacheman_settings' );
 define( 'ZW_CACHEMAN_CRON_HOOK', 'zw_cacheman_cron_hook' );
-define( 'ZW_CACHEMAN_WARM_HOOK', 'zw_cacheman_warm_hook' );
 define( 'ZW_CACHEMAN_WARM_QUEUE', 'zw_cacheman_warm_queue' );
 
 // Includes required files.
@@ -102,10 +101,6 @@ function zw_cacheman_deactivate() {
 	if ( $timestamp ) {
 		wp_unschedule_event( $timestamp, ZW_CACHEMAN_CRON_HOOK );
 	}
-
-	// Clear pending one-off warming events. wp_unschedule_hook() clears them
-	// regardless of their per-URL args (wp_clear_scheduled_hook() would not).
-	wp_unschedule_hook( ZW_CACHEMAN_WARM_HOOK );
 }
 register_deactivation_hook( __FILE__, 'zw_cacheman_deactivate' );
 

--- a/zw-cacheman.php
+++ b/zw-cacheman.php
@@ -25,6 +25,8 @@ define( 'ZW_CACHEMAN_QUEUE', 'zw_cacheman_queue' );
 define( 'ZW_CACHEMAN_SETTINGS', 'zw_cacheman_settings' );
 define( 'ZW_CACHEMAN_CRON_HOOK', 'zw_cacheman_cron_hook' );
 define( 'ZW_CACHEMAN_WARM_QUEUE', 'zw_cacheman_warm_queue' );
+define( 'ZW_CACHEMAN_WARM_QUEUE_LOCK', 'zw_cacheman_warm_queue_lock' );
+define( 'ZW_CACHEMAN_WARM_QUEUE_OVERFLOW', 'zw_cacheman_warm_queue_overflow' );
 
 // Includes required files.
 require_once ZW_CACHEMAN_DIR . 'includes/enum-purge-type.php';
@@ -114,6 +116,8 @@ function zw_cacheman_uninstall() {
 	delete_option( ZW_CACHEMAN_SETTINGS );
 	delete_option( ZW_CACHEMAN_QUEUE );
 	delete_option( ZW_CACHEMAN_WARM_QUEUE );
+	delete_option( ZW_CACHEMAN_WARM_QUEUE_LOCK );
+	delete_transient( ZW_CACHEMAN_WARM_QUEUE_OVERFLOW );
 
 	// Clean up log directory.
 	$upload_dir = wp_upload_dir();

--- a/zw-cacheman.php
+++ b/zw-cacheman.php
@@ -25,6 +25,7 @@ define( 'ZW_CACHEMAN_QUEUE', 'zw_cacheman_queue' );
 define( 'ZW_CACHEMAN_SETTINGS', 'zw_cacheman_settings' );
 define( 'ZW_CACHEMAN_CRON_HOOK', 'zw_cacheman_cron_hook' );
 define( 'ZW_CACHEMAN_WARM_HOOK', 'zw_cacheman_warm_hook' );
+define( 'ZW_CACHEMAN_WARM_QUEUE', 'zw_cacheman_warm_queue' );
 
 // Includes required files.
 require_once ZW_CACHEMAN_DIR . 'includes/enum-purge-type.php';
@@ -117,6 +118,7 @@ function zw_cacheman_uninstall() {
 	// Clean up all plugin data.
 	delete_option( ZW_CACHEMAN_SETTINGS );
 	delete_option( ZW_CACHEMAN_QUEUE );
+	delete_option( ZW_CACHEMAN_WARM_QUEUE );
 
 	// Clean up log directory.
 	$upload_dir = wp_upload_dir();

--- a/zw-cacheman.php
+++ b/zw-cacheman.php
@@ -25,7 +25,6 @@ define( 'ZW_CACHEMAN_QUEUE', 'zw_cacheman_queue' );
 define( 'ZW_CACHEMAN_SETTINGS', 'zw_cacheman_settings' );
 define( 'ZW_CACHEMAN_CRON_HOOK', 'zw_cacheman_cron_hook' );
 define( 'ZW_CACHEMAN_WARM_QUEUE', 'zw_cacheman_warm_queue' );
-define( 'ZW_CACHEMAN_WARM_QUEUE_LOCK', 'zw_cacheman_warm_queue_lock' );
 define( 'ZW_CACHEMAN_WARM_QUEUE_OVERFLOW', 'zw_cacheman_warm_queue_overflow' );
 
 // Includes required files.
@@ -57,7 +56,7 @@ function zw_cacheman_init() {
 
 	$sitemap_provider = ZW_CACHEMAN_Core\CachemanSitemapProviderFactory::detect( $logger );
 	$url_delver       = new ZW_CACHEMAN_Core\CachemanUrlDelver( $url_helper, $logger, $sitemap_provider );
-	$warmer           = new ZW_CACHEMAN_Core\CachemanWarmer( $logger, ! empty( $settings['enable_warming'] ) );
+	$warmer           = new ZW_CACHEMAN_Core\CachemanWarmer( $logger );
 	$manager          = new ZW_CACHEMAN_Core\CachemanManager( $api, $url_delver, $logger, $warmer );
 
 	// Only load admin interface in admin area.
@@ -116,7 +115,6 @@ function zw_cacheman_uninstall() {
 	delete_option( ZW_CACHEMAN_SETTINGS );
 	delete_option( ZW_CACHEMAN_QUEUE );
 	delete_option( ZW_CACHEMAN_WARM_QUEUE );
-	delete_option( ZW_CACHEMAN_WARM_QUEUE_LOCK );
 	delete_transient( ZW_CACHEMAN_WARM_QUEUE_OVERFLOW );
 
 	// Clean up log directory.


### PR DESCRIPTION
## Summary

Adds optional cache warming after successful Cloudflare purges. The setting is off by default.

- Queues exact `File` purge URLs; skips prefix purges and WordPress REST API URLs.
- Uses a 500-entry lease queue with pending-URL deduplication. Re-purges during an active fetch keep a separate generation.
- Warms at most five URLs per every-minute WP-Cron run. Transport failures rotate to the queue tail.
- Supports an optional 64-character `ZW_CACHEMAN_WARM_TOKEN` for Cloudflare WAF exceptions, with status shown in the admin.
- Cleans up queue, lock, and overflow state on uninstall.

## Validation

- `php -l includes/warmer.php`
- `php -l zw-cacheman.php`
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- Isolated checks for in-flight re-purges and retry rotation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in **Warm Cache After Purge** setting under **Settings → ZuidWest Cache → Configuration** to refresh eligible pages in the background after successful purges.
  * Only file purge URLs are warmed (excluding WordPress REST API paths and all prefix purges), with URL deduplication, queue limits, and WP-Cron batch processing.
  * Warm-up requests are unauthenticated by default or use a secured per-installation WAF token; transport failures retry, while HTTP `4xx/5xx` are not retried.

* **Documentation**
  * Updated the README with eligibility rules, queue and retry behavior, and secure WAF/token setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->