### PR TITLE
fix: close purge queue consumer race and bound cron pass duration

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -147,6 +147,8 @@ readonly class CachemanAdmin {
 				'name'    => 'batch_size',
 				'type'    => 'number',
 				'default' => 30,
+				'min'     => 1,
+				'max'     => CachemanAPI::PREFIX_BATCH_SIZE,
 			]
 		);
 
@@ -198,7 +200,7 @@ readonly class CachemanAdmin {
 	/**
 	 * Render settings field
 	 *
-	 * @param array{name: string, type: string, default?: mixed} $args Field arguments.
+	 * @param array{name: string, type: string, default?: mixed, min?: int, max?: int} $args Field arguments.
 	 */
 	public function render_field( array $args ): void {
 		$settings = get_option( ZW_CACHEMAN_SETTINGS, self::DEFAULT_SETTINGS );
@@ -215,11 +217,13 @@ readonly class CachemanAdmin {
 				esc_attr( $value )
 			),
 			'number' => printf(
-				'<input type="number" id="%s" name="%s[%s]" value="%s" class="regular-text" />',
+				'<input type="number" id="%s" name="%s[%s]" value="%s" min="%s" max="%s" class="regular-text" />',
 				esc_attr( $name ),
 				esc_attr( ZW_CACHEMAN_SETTINGS ),
 				esc_attr( $name ),
-				esc_attr( $value )
+				esc_attr( $value ),
+				esc_attr( (string) ( $args['min'] ?? 1 ) ),
+				esc_attr( (string) ( $args['max'] ?? '' ) )
 			),
 			'checkbox' => printf(
 				'<input type="checkbox" id="%s" name="%s[%s]" value="1" %s />',
@@ -271,14 +275,19 @@ readonly class CachemanAdmin {
 			? sanitize_text_field( $input['api_key'] )
 			: $old_settings['api_key']; // Keep old API key if empty (to prevent accidental clear).
 
-		// Sanitize numeric fields.
+		// Sanitize numeric fields. Capped at PREFIX_BATCH_SIZE so one cron
+		// pass sends at most one files and one prefixes request to Cloudflare.
 		$sanitized['batch_size'] = isset( $input['batch_size'] ) ? intval( $input['batch_size'] ) : 30;
-		if ( $sanitized['batch_size'] < 1 ) {
+		if ( $sanitized['batch_size'] < 1 || $sanitized['batch_size'] > CachemanAPI::PREFIX_BATCH_SIZE ) {
 			$sanitized['batch_size'] = 30;
 			add_settings_error(
 				'zw_cacheman_settings',
 				'invalid_batch_size',
-				__( 'Batch size must be at least 1. Reset to default (30).', 'zw-cacheman' ),
+				sprintf(
+					/* translators: %d: maximum allowed batch size */
+					__( 'Batch size must be between 1 and %d. Reset to default (30).', 'zw-cacheman' ),
+					CachemanAPI::PREFIX_BATCH_SIZE
+				),
 				'error'
 			);
 		}

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -686,11 +686,13 @@ readonly class CachemanAdmin {
 
 			case 'clear_queue':
 				check_admin_referer( 'zw_cacheman_clear_queue', 'zw_cacheman_queue_nonce' );
-				$queue       = get_option( ZW_CACHEMAN_QUEUE, [] );
-				$queue_count = count( $queue );
-				$this->logger->debug( 'Admin', 'Manually cleared queue with ' . $queue_count . ' items' );
-				delete_option( ZW_CACHEMAN_QUEUE );
-				$redirect_args = [ 'zw_message' => 'queue_cleared' ];
+				$queue_count = $this->manager->clear_purge_queue();
+				if ( null === $queue_count ) {
+					$redirect_args = [ 'zw_message' => 'queue_clear_failed' ];
+				} else {
+					$this->logger->debug( 'Admin', 'Manually cleared queue with ' . $queue_count . ' items' );
+					$redirect_args = [ 'zw_message' => 'queue_cleared' ];
+				}
 				break;
 
 			case 'clear_logs':
@@ -732,6 +734,7 @@ readonly class CachemanAdmin {
 
 			$notices = [
 				'queue_cleared'       => [ 'success', __( 'Cache queue has been cleared.', 'zw-cacheman' ) ],
+				'queue_clear_failed'  => [ 'error', __( 'Cache queue could not be cleared. Please try again.', 'zw-cacheman' ) ],
 				'connection_success'  => [ 'success', __( 'Cloudflare API connection successful!', 'zw-cacheman' ) . ' ' . $details ],
 				'connection_error'    => [ 'error', __( 'Cloudflare API connection failed: ', 'zw-cacheman' ) . $details ],
 				'missing_credentials' => [ 'error', __( 'Please enter both Zone ID and API Key to test the connection.', 'zw-cacheman' ) ],

--- a/includes/api.php
+++ b/includes/api.php
@@ -25,9 +25,10 @@ readonly class CachemanAPI {
 	/**
 	 * Conservative batch size for prefix purge requests. The API caps prefix
 	 * purges at 100 per request (error 1117); 30 stays well under the limit
-	 * across plan types.
+	 * across plan types. Also the upper bound for the batch_size setting, so
+	 * one queue pass sends at most one files and one prefixes request.
 	 */
-	private const PREFIX_BATCH_SIZE = 30;
+	public const PREFIX_BATCH_SIZE = 30;
 
 	/**
 	 * Constructor

--- a/includes/cache-manager.php
+++ b/includes/cache-manager.php
@@ -237,7 +237,28 @@ readonly class CachemanManager {
 	}
 
 	/**
-	 * Queue purge items for later processing
+	 * Stable identity of a purge item, used for queue deduplication and for
+	 * removing processed items.
+	 *
+	 * @param array{type: PurgeType, url: string} $item Purge item.
+	 * @return string
+	 */
+	private static function item_key( array $item ): string {
+		return $item['type']->value . '|' . $item['url'];
+	}
+
+	/**
+	 * Queue purge items for later processing.
+	 *
+	 * Read-modify-write on a plain option: two producers saving in the same
+	 * instant can read the same snapshot, and the last writer wins (the
+	 * other save's items are lost). This is accepted: the window is the few
+	 * milliseconds between the read and the write below (no network I/O in
+	 * between), so it takes two saves in the same instant to hit it. Closing
+	 * it would require a lock or a real job store, which this plugin
+	 * deliberately avoids. The consumer-side race is the dangerous one
+	 * (its window spans the Cloudflare calls) and is closed in
+	 * process_purge_queue() by re-reading the queue after those calls.
 	 *
 	 * @param array<array{type: PurgeType, url: string}> $purge_items Items to add to the queue.
 	 */
@@ -254,7 +275,7 @@ readonly class CachemanManager {
 
 		// Process existing items first.
 		foreach ( $existing_items as $item ) {
-			$key = $item['type']->value . '|' . $item['url'];
+			$key = self::item_key( $item );
 			if ( ! isset( $unique_keys[ $key ] ) ) {
 				$unique_keys[ $key ] = true;
 				$all_items[]         = $item;
@@ -263,7 +284,7 @@ readonly class CachemanManager {
 
 		// Add new items if not already in queue.
 		foreach ( $purge_items as $item ) {
-			$key = $item['type']->value . '|' . $item['url'];
+			$key = self::item_key( $item );
 			if ( ! isset( $unique_keys[ $key ] ) ) {
 				$unique_keys[ $key ] = true;
 				$all_items[]         = $item;
@@ -277,7 +298,18 @@ readonly class CachemanManager {
 	}
 
 	/**
-	 * Process the queue - called by WP-Cron
+	 * Process the queue - called by WP-Cron.
+	 *
+	 * Worst-case duration of one pass: batch_size is capped at
+	 * CachemanAPI::PREFIX_BATCH_SIZE (30), so the purge phase sends at most
+	 * one 'files' and one 'prefixes' request (2 x 30s timeout = 60s), and
+	 * the warm phase adds at most 5 fetches x 10s = 50s (see CachemanWarmer).
+	 * That 110s bound exceeds WordPress's cron lock (WP_CRON_LOCK_TIMEOUT,
+	 * 60s by default), so a slow pass can overlap the next spawn. Overlap is
+	 * benign: both runs may purge the same head-of-queue batch (duplicate
+	 * Cloudflare requests), but the diff-based queue update in
+	 * process_purge_queue() never drops concurrently enqueued items, and the
+	 * warm queue is best-effort by design.
 	 */
 	public function process_queue(): void {
 		$this->process_purge_queue();
@@ -289,6 +321,13 @@ readonly class CachemanManager {
 
 	/**
 	 * Purge a batch of queued items.
+	 *
+	 * The Cloudflare calls can take tens of seconds, and producers keep
+	 * enqueueing in the meantime. So instead of writing back a pre-call
+	 * snapshot (which would erase those concurrent enqueues), the queue is
+	 * re-read after the calls and only the successfully purged items are
+	 * removed. Failed items keep their place at the head of the queue and
+	 * retry next run; a queue cleared from the admin mid-pass stays cleared.
 	 */
 	private function process_purge_queue(): void {
 		$queue = get_option( ZW_CACHEMAN_QUEUE, [] );
@@ -300,26 +339,54 @@ readonly class CachemanManager {
 		$settings   = get_option( ZW_CACHEMAN_SETTINGS, [] );
 		$batch_size = ! empty( $settings['batch_size'] ) ? (int) $settings['batch_size'] : 30;
 
-		// Take a batch of items from the queue.
-		$items_to_process = array_slice( $queue, 0, $batch_size );
-		$remaining_items  = array_slice( $queue, $batch_size );
+		// Clamp values stored before sanitize_settings() enforced the cap.
+		$batch_size = max( 1, min( $batch_size, CachemanAPI::PREFIX_BATCH_SIZE ) );
 
-		$this->logger->debug( 'Manager', 'Processing ' . count( $items_to_process ) . ' items (' . count( $remaining_items ) . ' remaining)' );
+		// Take a batch of items from the head of the queue.
+		$items_to_process = array_slice( $queue, 0, $batch_size );
+		$remaining_count  = count( $queue ) - count( $items_to_process );
+
+		$this->logger->debug( 'Manager', 'Processing ' . count( $items_to_process ) . ' items (' . $remaining_count . ' remaining)' );
 
 		$failed_items = $this->purge_items( $items_to_process );
+
+		$failed_keys = [];
+		foreach ( $failed_items as $item ) {
+			$failed_keys[ self::item_key( $item ) ] = true;
+		}
+
+		$purged_keys = [];
+		foreach ( $items_to_process as $item ) {
+			$key = self::item_key( $item );
+			if ( ! isset( $failed_keys[ $key ] ) ) {
+				$purged_keys[ $key ] = true;
+			}
+		}
+
+		if ( empty( $purged_keys ) ) {
+			$this->logger->error( 'Manager', 'Failed to process batch of ' . count( $items_to_process ) . ' items. Will retry next run.' );
+			return;
+		}
+
+		// Re-read the queue and drop only what was purged (autoload disabled
+		// for performance).
+		$current_queue = get_option( ZW_CACHEMAN_QUEUE, [] );
+		$next_queue    = array_values(
+			array_filter(
+				$current_queue,
+				static fn ( array $item ): bool => ! isset( $purged_keys[ self::item_key( $item ) ] )
+			)
+		);
+
+		update_option( ZW_CACHEMAN_QUEUE, $next_queue, false );
+
 		if ( empty( $failed_items ) ) {
-			// Update the queue with remaining items (autoload disabled for performance).
-			update_option( ZW_CACHEMAN_QUEUE, $remaining_items, false );
-			$this->logger->debug( 'Manager', 'Successfully processed batch. ' . count( $remaining_items ) . ' items remaining in queue.' );
-		} elseif ( count( $failed_items ) < count( $items_to_process ) ) {
-			$next_queue = array_merge( $failed_items, $remaining_items );
-			update_option( ZW_CACHEMAN_QUEUE, $next_queue, false );
+			$this->logger->debug( 'Manager', 'Successfully processed batch. ' . count( $next_queue ) . ' items remaining in queue.' );
+		} else {
 			$this->logger->error(
 				'Manager',
 				'Failed to process ' . count( $failed_items ) . ' of ' . count( $items_to_process ) . ' items. Failed items will retry next run.'
 			);
-		} else {
-			$this->logger->error( 'Manager', 'Failed to process batch of ' . count( $items_to_process ) . ' items. Will retry next run.' );
 		}
 	}
 }

--- a/includes/cache-manager.php
+++ b/includes/cache-manager.php
@@ -17,6 +17,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 readonly class CachemanManager {
 
 	/**
+	 * Maximum time spent waiting to mutate the purge queue.
+	 */
+	private const float QUEUE_LOCK_WAIT_SECONDS = 31.0;
+
+	/**
+	 * Time after which an abandoned purge queue lock may be taken over.
+	 */
+	private const float QUEUE_LOCK_TTL_SECONDS = 30.0;
+
+	/**
 	 * Constructor
 	 *
 	 * @param CachemanAPI       $api        The API handler instance.
@@ -248,17 +258,138 @@ readonly class CachemanManager {
 	}
 
 	/**
+	 * Invalidate one option in every cache used by get_option().
+	 *
+	 * @param string $option Option name.
+	 */
+	private static function invalidate_option_cache( string $option ): void {
+		wp_cache_delete( $option, 'options' );
+
+		foreach ( [ 'alloptions', 'notoptions' ] as $cache_key ) {
+			$cached_options = wp_cache_get( $cache_key, 'options' );
+			if ( is_array( $cached_options ) && isset( $cached_options[ $option ] ) ) {
+				unset( $cached_options[ $option ] );
+				wp_cache_set( $cache_key, $cached_options, 'options' );
+			}
+		}
+	}
+
+	/**
+	 * Read the current purge queue, bypassing any request-local snapshot.
+	 *
+	 * @return array<array{type: PurgeType, url: string}>
+	 */
+	private static function get_current_purge_queue(): array {
+		self::invalidate_option_cache( ZW_CACHEMAN_QUEUE );
+		$queue = get_option( ZW_CACHEMAN_QUEUE, [] );
+
+		return is_array( $queue ) ? $queue : [];
+	}
+
+	/**
+	 * Acquire the shared purge queue mutation lock.
+	 *
+	 * An INSERT IGNORE provides the atomic insert. The conditional database
+	 * update only recovers locks abandoned by a terminated request.
+	 *
+	 * @return string|null The owned lock value, or null when acquisition timed out.
+	 */
+	private function acquire_purge_queue_lock(): ?string {
+		global $wpdb;
+
+		$deadline = microtime( true ) + self::QUEUE_LOCK_WAIT_SECONDS;
+
+		do {
+			$lock_value = sprintf(
+				'%.6F:%s',
+				microtime( true ) + self::QUEUE_LOCK_TTL_SECONDS,
+				wp_generate_uuid4()
+			);
+
+			$inserted = $wpdb->query(
+				$wpdb->prepare(
+					'INSERT IGNORE INTO %i (option_name, option_value, autoload) VALUES (%s, %s, %s)',
+					$wpdb->options,
+					ZW_CACHEMAN_QUEUE_LOCK,
+					$lock_value,
+					'off'
+				)
+			);
+
+			if ( 1 === $inserted ) {
+				self::invalidate_option_cache( ZW_CACHEMAN_QUEUE_LOCK );
+				return $lock_value;
+			}
+
+			$stored_lock = $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT option_value FROM %i WHERE option_name = %s',
+					$wpdb->options,
+					ZW_CACHEMAN_QUEUE_LOCK
+				)
+			);
+
+			if ( ! is_string( $stored_lock ) ) {
+				self::invalidate_option_cache( ZW_CACHEMAN_QUEUE_LOCK );
+				usleep( 10_000 );
+				continue;
+			}
+
+			$expires_at = (float) strstr( $stored_lock, ':', true );
+			if ( $expires_at <= microtime( true ) ) {
+				$updated = $wpdb->query(
+					$wpdb->prepare(
+						'UPDATE %i SET option_value = %s WHERE option_name = %s AND option_value = %s',
+						$wpdb->options,
+						$lock_value,
+						ZW_CACHEMAN_QUEUE_LOCK,
+						$stored_lock
+					)
+				);
+
+				if ( 1 === $updated ) {
+					self::invalidate_option_cache( ZW_CACHEMAN_QUEUE_LOCK );
+					return $lock_value;
+				}
+			}
+
+			usleep( 10_000 );
+		} while ( microtime( true ) < $deadline );
+
+		return null;
+	}
+
+	/**
+	 * Release the purge queue mutation lock when it is still owned.
+	 *
+	 * @param string $lock_value Value returned by acquire_purge_queue_lock().
+	 */
+	private function release_purge_queue_lock( string $lock_value ): void {
+		global $wpdb;
+
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i WHERE option_name = %s AND option_value = %s',
+				$wpdb->options,
+				ZW_CACHEMAN_QUEUE_LOCK,
+				$lock_value
+			)
+		);
+
+		if ( 1 === $deleted ) {
+			self::invalidate_option_cache( ZW_CACHEMAN_QUEUE_LOCK );
+			return;
+		}
+
+		$this->logger->error( 'Manager', 'Purge queue mutation lock expired before it could be released.' );
+	}
+
+	/**
 	 * Queue purge items for later processing.
 	 *
-	 * Read-modify-write on a plain option: two producers saving in the same
-	 * instant can read the same snapshot, and the last writer wins (the
-	 * other save's items are lost). This is accepted: the window is the few
-	 * milliseconds between the read and the write below (no network I/O in
-	 * between), so it takes two saves in the same instant to hit it. Closing
-	 * it would require a lock or a real job store, which this plugin
-	 * deliberately avoids. The consumer-side race is the dangerous one
-	 * (its window spans the Cloudflare calls) and is closed in
-	 * process_purge_queue() by re-reading the queue after those calls.
+	 * Every queue read-modify-write operation uses the same short-lived lock,
+	 * preventing producers, consumers, and admin clears from overwriting each
+	 * other's changes.
 	 *
 	 * @param array<array{type: PurgeType, url: string}> $purge_items Items to add to the queue.
 	 */
@@ -267,34 +398,67 @@ readonly class CachemanManager {
 			return;
 		}
 
-		$existing_items = get_option( ZW_CACHEMAN_QUEUE, [] );
-
-		// Combine and deduplicate based on URL and type.
-		$all_items   = [];
-		$unique_keys = [];
-
-		// Process existing items first.
-		foreach ( $existing_items as $item ) {
-			$key = self::item_key( $item );
-			if ( ! isset( $unique_keys[ $key ] ) ) {
-				$unique_keys[ $key ] = true;
-				$all_items[]         = $item;
-			}
+		$lock_value = $this->acquire_purge_queue_lock();
+		if ( null === $lock_value ) {
+			$this->logger->error( 'Manager', 'Could not acquire purge queue lock; items were not queued.' );
+			return;
 		}
 
-		// Add new items if not already in queue.
-		foreach ( $purge_items as $item ) {
-			$key = self::item_key( $item );
-			if ( ! isset( $unique_keys[ $key ] ) ) {
-				$unique_keys[ $key ] = true;
-				$all_items[]         = $item;
+		try {
+			$existing_items = self::get_current_purge_queue();
+
+			// Combine and deduplicate based on URL and type.
+			$all_items   = [];
+			$unique_keys = [];
+
+			// Process existing items first.
+			foreach ( $existing_items as $item ) {
+				$key = self::item_key( $item );
+				if ( ! isset( $unique_keys[ $key ] ) ) {
+					$unique_keys[ $key ] = true;
+					$all_items[]         = $item;
+				}
 			}
+
+			// Add new items if not already in queue.
+			foreach ( $purge_items as $item ) {
+				$key = self::item_key( $item );
+				if ( ! isset( $unique_keys[ $key ] ) ) {
+					$unique_keys[ $key ] = true;
+					$all_items[]         = $item;
+				}
+			}
+
+			$added_count = count( $all_items ) - count( $existing_items );
+			update_option( ZW_CACHEMAN_QUEUE, $all_items, false );
+		} finally {
+			$this->release_purge_queue_lock( $lock_value );
 		}
 
-		$added_count = count( $all_items ) - count( $existing_items );
 		$this->logger->debug( 'Manager', 'Added ' . $added_count . ' new purge items to queue. Total in queue: ' . count( $all_items ) );
+	}
 
-		update_option( ZW_CACHEMAN_QUEUE, $all_items, false );
+	/**
+	 * Clear the purge queue while holding the shared mutation lock.
+	 *
+	 * @return int|null Number of removed items, or null when the lock timed out.
+	 */
+	public function clear_purge_queue(): ?int {
+		$lock_value = $this->acquire_purge_queue_lock();
+		if ( null === $lock_value ) {
+			$this->logger->error( 'Manager', 'Could not acquire purge queue lock; queue was not cleared.' );
+			return null;
+		}
+
+		try {
+			$queue       = self::get_current_purge_queue();
+			$queue_count = count( $queue );
+			delete_option( ZW_CACHEMAN_QUEUE );
+		} finally {
+			$this->release_purge_queue_lock( $lock_value );
+		}
+
+		return $queue_count;
 	}
 
 	/**
@@ -307,9 +471,8 @@ readonly class CachemanManager {
 	 * That 110s bound exceeds WordPress's cron lock (WP_CRON_LOCK_TIMEOUT,
 	 * 60s by default), so a slow pass can overlap the next spawn. Overlap is
 	 * benign: both runs may purge the same head-of-queue batch (duplicate
-	 * Cloudflare requests), but the diff-based queue update in
-	 * process_purge_queue() never drops concurrently enqueued items, and the
-	 * warm queue is best-effort by design.
+	 * Cloudflare requests), but all purge queue mutations use the same lock,
+	 * and the warm queue is best-effort by design.
 	 */
 	public function process_queue(): void {
 		$this->process_purge_queue();
@@ -326,8 +489,9 @@ readonly class CachemanManager {
 	 * enqueueing in the meantime. So instead of writing back a pre-call
 	 * snapshot (which would erase those concurrent enqueues), the queue is
 	 * re-read after the calls and only the successfully purged items are
-	 * removed. Failed items keep their place at the head of the queue and
-	 * retry next run; a queue cleared from the admin mid-pass stays cleared.
+	 * removed. The final read-modify-write uses the same short-lived lock as
+	 * producers and admin clears. Failed items keep their place at the head
+	 * of the queue and retry next run.
 	 */
 	private function process_purge_queue(): void {
 		$queue = get_option( ZW_CACHEMAN_QUEUE, [] );
@@ -368,17 +532,27 @@ readonly class CachemanManager {
 			return;
 		}
 
-		// Re-read the queue and drop only what was purged (autoload disabled
-		// for performance).
-		$current_queue = get_option( ZW_CACHEMAN_QUEUE, [] );
-		$next_queue    = array_values(
-			array_filter(
-				$current_queue,
-				static fn ( array $item ): bool => ! isset( $purged_keys[ self::item_key( $item ) ] )
-			)
-		);
+		$lock_value = $this->acquire_purge_queue_lock();
+		if ( null === $lock_value ) {
+			$this->logger->error( 'Manager', 'Could not acquire purge queue lock; purged items will retry next run.' );
+			return;
+		}
 
-		update_option( ZW_CACHEMAN_QUEUE, $next_queue, false );
+		try {
+			// Re-read the queue and drop only what was purged (autoload
+			// disabled for performance).
+			$current_queue = self::get_current_purge_queue();
+			$next_queue    = array_values(
+				array_filter(
+					$current_queue,
+					static fn ( array $item ): bool => ! isset( $purged_keys[ self::item_key( $item ) ] )
+				)
+			);
+
+			update_option( ZW_CACHEMAN_QUEUE, $next_queue, false );
+		} finally {
+			$this->release_purge_queue_lock( $lock_value );
+		}
 
 		if ( empty( $failed_items ) ) {
 			$this->logger->debug( 'Manager', 'Successfully processed batch. ' . count( $next_queue ) . ' items remaining in queue.' );

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -16,5 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'ZW_CACHEMAN_DIR', __DIR__ . '/' );
 define( 'ZW_CACHEMAN_URL', 'https://example.com/wp-content/plugins/zw-cacheman/' );
 define( 'ZW_CACHEMAN_QUEUE', 'zw_cacheman_queue' );
+define( 'ZW_CACHEMAN_QUEUE_LOCK', 'zw_cacheman_queue_lock' );
 define( 'ZW_CACHEMAN_SETTINGS', 'zw_cacheman_settings' );
 define( 'ZW_CACHEMAN_CRON_HOOK', 'zw_cacheman_process_queue' );

--- a/zw-cacheman.php
+++ b/zw-cacheman.php
@@ -22,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'ZW_CACHEMAN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'ZW_CACHEMAN_URL', plugin_dir_url( __FILE__ ) );
 define( 'ZW_CACHEMAN_QUEUE', 'zw_cacheman_queue' );
+define( 'ZW_CACHEMAN_QUEUE_LOCK', 'zw_cacheman_queue_lock' );
 define( 'ZW_CACHEMAN_SETTINGS', 'zw_cacheman_settings' );
 define( 'ZW_CACHEMAN_CRON_HOOK', 'zw_cacheman_cron_hook' );
 define( 'ZW_CACHEMAN_WARM_QUEUE', 'zw_cacheman_warm_queue' );
@@ -114,6 +115,7 @@ function zw_cacheman_uninstall() {
 	// Clean up all plugin data.
 	delete_option( ZW_CACHEMAN_SETTINGS );
 	delete_option( ZW_CACHEMAN_QUEUE );
+	delete_option( ZW_CACHEMAN_QUEUE_LOCK );
 	delete_option( ZW_CACHEMAN_WARM_QUEUE );
 	delete_transient( ZW_CACHEMAN_WARM_QUEUE_OVERFLOW );
 


### PR DESCRIPTION
Fixes #45.

## Assessment

The issue identifies two real lost-update races in the purge queue and an unbounded cron pass. The initial implementation closed the long network-call window by re-reading the queue, but review correctly identified that the final read-modify-write still had a shorter race. This PR now serializes every purge queue mutation with one lightweight lock stored in `wp_options`; no new table, dependency, or job-store abstraction is needed.

## Changes

**Queue mutations (serialized)** - `queue_purge_items()`, the consumer's final removal, and the admin clear action all use the same lock. Atomic acquisition uses `INSERT IGNORE`; expired-lock takeover and release are conditional on the exact stored owner value. The lock is held only for the local option mutation, never during Cloudflare or warming requests.

**Fresh queue reads** - locked mutations invalidate the request-local Options API caches before reading. This makes the consumer's post-request re-read an actual database read, so a value cached before the Cloudflare calls cannot overwrite newer queue state.

**Safe purge processing** - after the Cloudflare calls, `process_purge_queue()` removes only successfully purged items from the current queue, diffed by the shared `type|url` key. Failed items keep their place and retry. Concurrent producers and admin clears cannot be overwritten by stale snapshots.

**Time budget (bounded and documented)** - `batch_size` is capped at `CachemanAPI::PREFIX_BATCH_SIZE` (30, now public) in `sanitize_settings()`, and clamped again at the point of use so values stored before the cap existed are covered too. With the cap, one purge pass sends at most one `files` and one `prefixes` request: 2 x 30s timeout = 60s, plus up to 50s of warming. That 110s worst case is stated on `process_queue()`, together with why exceeding the 60s cron lock is benign: an overlapping run can at worst duplicate Cloudflare requests for the same head-of-queue batch, while serialized queue mutations preserve current state. The batch-size input also has `min`/`max` attributes.

## Acceptance criteria

- [x] Consumer no longer overwrites items enqueued during its network calls
- [x] Producer-vs-producer and final consumer mutation races are serialized
- [x] Admin clear cannot be undone by a stale consumer snapshot
- [x] Bounded worst-case cron pass duration stated in code; overlap behavior documented
- [x] `batch_size` capped in `sanitize_settings()`

## Verification

- `vendor/bin/phpcs`: clean
- `vendor/bin/phpstan analyse --debug --memory-limit=1G` (level 6): no errors
