### PR TITLE
fix(ci): allow Plugin Check PR comments

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,4 +30,7 @@ permissions:
 
 jobs:
   lint:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: oszuidwest/.github-templates/.github/workflows/wp-ci.yml@v2


### PR DESCRIPTION
## Summary

- grant the reusable WP CI job pull-requests: write
- allow Plugin Check to publish or update its pull-request result comment
- keep the workflow-level token read-only

Related to oszuidwest/.github-templates#50.

## Validation

- git diff --check
- actionlint .github/workflows/lint.yml
- yamllint .github/workflows/lint.yml (existing truthy warning for the unquoted on key only)